### PR TITLE
Bugfix: comment out variable font weights option in admin settings for future release

### DIFF
--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -1287,6 +1287,13 @@ $manual_fonts = $instance->get_manual_fonts();
                                 </p>
                             </td>
                         </tr>
+                        <?php
+                        /*
+                         * Variable Font Weights option - commented out for future version
+                         * Backend functionality remains in place, UI option hidden until ready for release
+                         */
+                        ?>
+                        <?php /* ?>
                         <tr>
                             <th scope="row">
                                 <label for="ots_allow_variable_weights">
@@ -1309,6 +1316,7 @@ $manual_fonts = $instance->get_manual_fonts();
                                 </p>
                             </td>
                         </tr>
+                        <?php */ ?>
                     </tbody>
                 </table>
 


### PR DESCRIPTION
This pull request makes a minor update to the `includes/admin-page.php` file by commenting out the UI for the "Variable Font Weights" option. The backend functionality for this option remains in place, but the UI is hidden for now in preparation for a future release. No other significant changes are included.

- Commented out the UI elements for the "Variable Font Weights" option in the admin page, while retaining the backend logic for future use. [[1]](diffhunk://#diff-93dde6caaeaef5a63b4a867c8bed645351ac9a4899e7a23e1d2951d435e4f876R1290-R1296) [[2]](diffhunk://#diff-93dde6caaeaef5a63b4a867c8bed645351ac9a4899e7a23e1d2951d435e4f876R1319)