### PR TITLE
fix: Implement cache clearing on post save and delete 

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,16 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ## Changelog
 
+### Version 1.1.9
+
+**Cache & Font Loading Improvements:**
+- Fixed: Archive page font loading - fonts now load correctly on blog home, category pages, tag pages, and all archive types
+- Fixed: WordPress hook timing issue - font detection now runs on `template_redirect` hook (after main query) instead of `wp_enqueue_scripts` (before query) for archive pages
+- Added: Manual cache clear button in Settings → Typography Stylist → Options tab
+- Added: Admin setting to control archive page full content checking (enabled by default)
+- Improved: Font detection caches now automatically clear when posts or pages are saved, so typography changes appear on the frontend immediately
+- Improved: Cache clearing when options are changed to ensure settings take effect immediately
+
 ### Version 1.1.6
 
 **Control Order Improvements:**

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Added: Admin setting to control archive page full content checking (enabled by default)
 * Improved: Singular pages (posts, pages) continue using optimized detection path without changes
 * Improved: Cache clearing when options are changed to ensure settings take effect immediately
+* Improved: Font detection caches now automatically clear when posts or pages are saved, so typography changes appear on the frontend immediately
 * Updated: Filter `typost_check_full_content_on_archives` now defaults to true (was false)
 * Technical: Font detection results cached in instance variables to avoid redundant queries
 * Note: Existing sites will automatically benefit from improved archive page font loading

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matthewneilcowan
 Tags: typography, opentype, ligatures, stylistic-sets, webfonts
 Requires at least: 5.8
 Tested up to: 6.9.1
-Stable tag: 1.1.8
+Stable tag: 1.1.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -93,7 +93,7 @@ Check the font's documentation or specimen to verify which OpenType features are
 
 1. Upload the plugin files to `/wp-content/plugins/opentype-stylist`, or install through the WordPress plugins screen
 2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Go to Settings → Headline Typography to view available features and presets
+3. Go to Settings → Typography Stylist to view available features and presets
 4. Start using the typography features in the block editor!
 
 == Frequently Asked Questions ==
@@ -165,12 +165,12 @@ The plugin includes accessibility features for screen reader compatibility:
 * **Inline Format Warnings**: Detects when you select partial words (which can fragment text for screen readers) and shows a warning with options to convert to an accessible block or apply anyway
 * **Typography Stylist Block**: Custom block designed for complex typography that includes ARIA markup with screen reader-accessible text
 * **ARIA Label Support**: Optional setting to add aria-label attributes to inline formatted text (Settings → Typography Stylist → Accessibility)
-* **Screen Reader Classes**: the Typography Stylist block uses configurable classes (visually-hidden, sr-only, or custom) to hide styled text from screen readers while providing clean text
+* **Screen Reader Classes**: The Typography Stylist block uses configurable classes (visually-hidden, sr-only, or custom) to hide styled text from screen readers while providing clean text
 * **Dual Content Approach**: The block provides duplicate content - one version styled for visual users, one clean version for assistive technology
 
 = How do the accessibility features for the block work? =
 
-the Typography Stylist block creates two versions of your text:
+The Typography Stylist block creates two versions of your text:
 
 1. **For screen readers**: Clean, unformatted text in a semantic heading element (H1-H6) with the `visually-hidden` class applied. This maintains the document outline and heading navigation for assistive technology users.
 2. **For visual display**: Styled text with `aria-hidden="true"` to prevent screen readers from reading fragmented content with complex OpenType features.

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -1886,18 +1886,22 @@ class Typost {
      * Clears stale font detection transients when post content changes,
      * ensuring the frontend re-detects fonts on the next page load.
      *
-     * @since 1.2.0
+     * @since 1.1.9
      *
-     * @param int     $post_id Post ID.
-     * @param WP_Post $post    Post object.
-     * @param bool    $update  Whether this is an update to an existing post.
+     * @param int     $post_id  Post ID.
+     * @param WP_Post $_post    Post object. Unused but required by the save_post hook signature.
+     * @param bool    $_update  Whether this is an update to an existing post. Unused but required by the hook.
      */
-    public function on_post_save($post_id, $post, $update) {
+    public function on_post_save($post_id, $_post, $_update) {
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
             return;
         }
 
         if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        if (!in_array(get_post_status($post_id), array('publish', 'private'), true)) {
             return;
         }
 
@@ -1907,7 +1911,7 @@ class Typost {
     /**
      * Handle post deletion: clear per-post and archive font detection caches.
      *
-     * @since 1.2.0
+     * @since 1.1.9
      *
      * @param int $post_id Post ID being deleted.
      */
@@ -1932,7 +1936,7 @@ class Typost {
      * because they are keyed by font combination -- when a post's used fonts
      * change, a new cache key is generated automatically.
      *
-     * @since 1.2.0
+     * @since 1.1.9
      * @access private
      *
      * @param int $post_id Post ID whose caches should be cleared.
@@ -1946,6 +1950,8 @@ class Typost {
         // Clear per-post transients (exact key, no wildcard needed)
         delete_transient('typost_has_styled_' . $post_id);
         delete_transient('typost_used_fonts_' . $post_id);
+        wp_cache_delete('typost_has_styled_' . $post_id, 'transient');
+        wp_cache_delete('typost_used_fonts_' . $post_id, 'transient');
 
         // Clear all archive page caches.
         // Archive cache keys use MD5(serialized post IDs), so we cannot target
@@ -1964,6 +1970,9 @@ class Typost {
             )
         );
         // phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+        // Flush object cache to clear archive transients stored in persistent cache (Redis, Memcached)
+        wp_cache_flush();
     }
 
     /**

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -93,6 +93,10 @@ class Typost {
         // Enqueue frontend assets
         add_action('wp_enqueue_scripts', array($this, 'enqueue_frontend_assets'));
 
+        // Clear per-post and archive caches when posts are saved or deleted
+        add_action('save_post', array($this, 'on_post_save'), 10, 3);
+        add_action('before_delete_post', array($this, 'on_post_delete'));
+
         // Output CSS variables for fonts
         add_action('wp_head', array($this, 'output_font_css_variables'), 5);
         add_action('admin_head', array($this, 'output_font_css_variables'), 5);
@@ -1874,6 +1878,92 @@ class Typost {
             // Flush object cache for transient group
             wp_cache_flush();
         }
+    }
+
+    /**
+     * Handle post save: clear per-post and archive font detection caches.
+     *
+     * Clears stale font detection transients when post content changes,
+     * ensuring the frontend re-detects fonts on the next page load.
+     *
+     * @since 1.2.0
+     *
+     * @param int     $post_id Post ID.
+     * @param WP_Post $post    Post object.
+     * @param bool    $update  Whether this is an update to an existing post.
+     */
+    public function on_post_save($post_id, $post, $update) {
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        $this->clear_post_content_caches($post_id);
+    }
+
+    /**
+     * Handle post deletion: clear per-post and archive font detection caches.
+     *
+     * @since 1.2.0
+     *
+     * @param int $post_id Post ID being deleted.
+     */
+    public function on_post_delete($post_id) {
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        $this->clear_post_content_caches($post_id);
+    }
+
+    /**
+     * Clear font detection caches related to a specific post.
+     *
+     * Removes per-post transients for styled content detection and used fonts,
+     * plus all archive page caches (which cannot be targeted by post ID because
+     * they use MD5 hashes of serialized post ID arrays as cache keys).
+     *
+     * Does NOT clear global font CSS caches (admin_font_css, editor_font_css,
+     * block_font_css, css_variables) because those only change when fonts
+     * themselves are added/removed/modified. Does NOT clear font_css_* caches
+     * because they are keyed by font combination -- when a post's used fonts
+     * change, a new cache key is generated automatically.
+     *
+     * @since 1.2.0
+     * @access private
+     *
+     * @param int $post_id Post ID whose caches should be cleared.
+     */
+    private function clear_post_content_caches($post_id) {
+        $post_id = absint($post_id);
+        if (!$post_id) {
+            return;
+        }
+
+        // Clear per-post transients (exact key, no wildcard needed)
+        delete_transient('typost_has_styled_' . $post_id);
+        delete_transient('typost_used_fonts_' . $post_id);
+
+        // Clear all archive page caches.
+        // Archive cache keys use MD5(serialized post IDs), so we cannot target
+        // specific archives containing this post. Wildcard delete is required.
+        // Direct database call is required for bulk deletion of transients with wildcard patterns.
+        // No caching needed as this is a delete operation.
+        global $wpdb;
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s",
+                $wpdb->esc_like('_transient_typost_has_styled_archive_') . '%',
+                $wpdb->esc_like('_transient_timeout_typost_has_styled_archive_') . '%',
+                $wpdb->esc_like('_transient_typost_used_fonts_archive_') . '%',
+                $wpdb->esc_like('_transient_timeout_typost_used_fonts_archive_') . '%'
+            )
+        );
+        // phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
     }
 
     /**


### PR DESCRIPTION
Closes #88 

This pull request enhances the cache management for font detection in the plugin by ensuring that relevant caches are properly cleared when posts are saved or deleted. This helps keep font-related data accurate and up-to-date on the frontend and archive pages.

**Cache Invalidation Improvements:**

* Added hooks to trigger cache clearing when a post is saved (`save_post`) or deleted (`before_delete_post`), ensuring that stale font detection transients are removed automatically.
* Implemented the `on_post_save` and `on_post_delete` methods to handle cache invalidation for individual posts, skipping autosaves and revisions.
* Introduced a private `clear_post_content_caches` method that deletes per-post transients and performs a wildcard database query to remove all relevant archive page caches, ensuring font detection is re-run as needed.