### PR TITLE
Bufix/#86 second line

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -45,6 +45,7 @@ Thumbs.db
 
 # Documentation (except main README)
 docs/
+todo/
 CONTRIBUTING.md
 CHANGELOG.md
 LICENSE.md

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -94,6 +94,61 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
     }
 
     /**
+     * Build a text offset map from a DOM container, accounting for <br> elements.
+     *
+     * Designed to match WordPress RichText's offset system, where each <br> element
+     * (inserted via Shift+Enter) counts as 1 character position. Without this adjustment,
+     * offsets from wp.richText value.start / value.end would be misaligned with text
+     * node positions, causing styles to be applied to the wrong character.
+     *
+     * Returns only text node entries — <br> elements increment the running offset by 1
+     * but do not produce entries in the returned array, since they cannot be split or
+     * wrapped in <span> elements.
+     *
+     * @param {Node} container - DOM node to walk
+     * @param {Document} docContext - Document context for creating the TreeWalker
+     * @return {Array<{node: Node, start: number, end: number, text: string}>}
+     */
+    function buildTextOffsetMap(container, docContext) {
+        var walker = docContext.createTreeWalker(
+            container,
+            NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+            {
+                acceptNode: function(node) {
+                    if (node.nodeType === Node.TEXT_NODE) {
+                        return NodeFilter.FILTER_ACCEPT;
+                    }
+                    if (node.nodeName === 'BR') {
+                        return NodeFilter.FILTER_ACCEPT;
+                    }
+                    return NodeFilter.FILTER_SKIP;
+                }
+            }
+        );
+
+        var map = [];
+        var currentOffset = 0;
+        var node;
+
+        while ((node = walker.nextNode())) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                var text = node.nodeValue || '';
+                map.push({
+                    node: node,
+                    start: currentOffset,
+                    end: currentOffset + text.length,
+                    text: text
+                });
+                currentOffset += text.length;
+            } else if (node.nodeName === 'BR') {
+                currentOffset += 1;
+            }
+        }
+
+        return map;
+    }
+
+    /**
      * Get block's inherited font-family from computed styles
      * Detects the current font applied by theme or block settings
      *
@@ -329,29 +384,24 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             let smallestMatchingSpan = null;
             let smallestSpanSize = Infinity;
 
+            // Build offset map once (accounts for <br> line breaks)
+            const textNodeMap = buildTextOffsetMap(container, doc);
+
             // Calculate character offset for each span
             for (const span of styledSpans) {
-                // Find this span's position in the text
-                const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+                // Find this span's position in the text using pre-built map
                 let spanStart = 0;
                 let spanEnd = 0;
                 let found = false;
-                let offset = 0;
 
-                let node;
-                while ((node = walker.nextNode())) {
-                    const nodeLength = node.nodeValue.length;
-
-                    // Check if this text node is inside our span
-                    if (span.contains(node)) {
+                for (const entry of textNodeMap) {
+                    if (span.contains(entry.node)) {
                         if (!found) {
-                            spanStart = offset;
+                            spanStart = entry.start;
                             found = true;
                         }
-                        spanEnd = offset + nodeLength;
+                        spanEnd = entry.end;
                     }
-
-                    offset += nodeLength;
                 }
 
                 // Check if the selection overlaps with this span
@@ -1036,28 +1086,22 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                         return;
                     }
 
-                    // Create a range for the selection
-                    const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-                    let currentOffset = 0;
+                    // Create a range for the selection (accounts for <br> line breaks)
+                    const selTextMap = buildTextOffsetMap(container, doc);
                     let startNode = null, startOffset = 0;
                     let endNode = null, endOffset = 0;
 
-                    let textNode;
-                    while ((textNode = walker.nextNode())) {
-                        const nodeLength = textNode.nodeValue.length;
-
-                        if (!startNode && currentOffset + nodeLength >= value.start) {
-                            startNode = textNode;
-                            startOffset = value.start - currentOffset;
+                    for (const entry of selTextMap) {
+                        if (!startNode && entry.end >= value.start) {
+                            startNode = entry.node;
+                            startOffset = value.start - entry.start;
                         }
 
-                        if (currentOffset + nodeLength >= value.end) {
-                            endNode = textNode;
-                            endOffset = value.end - currentOffset;
+                        if (entry.end >= value.end) {
+                            endNode = entry.node;
+                            endOffset = value.end - entry.start;
                             break;
                         }
-
-                        currentOffset += nodeLength;
                     }
 
                     // If we found the nodes, wrap the selection

--- a/blocks/typography-stylist/__tests__/br-offset.test.js
+++ b/blocks/typography-stylist/__tests__/br-offset.test.js
@@ -1,0 +1,223 @@
+/**
+ * Test Suite: BR Line Break Offset Handling
+ *
+ * Tests that <br> elements (hard returns from Shift+Enter) are counted as
+ * 1 character position in offset calculations, matching WordPress RichText's
+ * offset system.
+ *
+ * Bug: When content contains <br> tags, styling applied to text after the
+ * line break would target the wrong character (off by 1 per <br>).
+ */
+
+import {
+	buildTextOffsetMap,
+	getEffectiveTextLength,
+	parseInlineFeaturesAtCursor,
+	parseInlineStylesAtCursor,
+	applyStylingSafeStringMethod
+} from '../utils';
+
+// Helper to create a parsed DOM container
+function createContainer(html) {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(`<div>${html}</div>`, 'text/html');
+	return { container: doc.body.firstChild, doc };
+}
+
+describe('buildTextOffsetMap - BR handling', () => {
+
+	it('should count BR as 1 character position', () => {
+		const { container, doc } = createContainer('Line1<br>Line2');
+		const map = buildTextOffsetMap(container, doc);
+
+		expect(map).toHaveLength(2);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 5, text: 'Line1' }));
+		// BR at position 5, so Line2 starts at 6
+		expect(map[1]).toEqual(expect.objectContaining({ start: 6, end: 11, text: 'Line2' }));
+	});
+
+	it('should handle multiple BRs cumulatively', () => {
+		const { container, doc } = createContainer('A<br>B<br>C');
+		const map = buildTextOffsetMap(container, doc);
+
+		expect(map).toHaveLength(3);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 1, text: 'A' }));
+		expect(map[1]).toEqual(expect.objectContaining({ start: 2, end: 3, text: 'B' }));
+		expect(map[2]).toEqual(expect.objectContaining({ start: 4, end: 5, text: 'C' }));
+	});
+
+	it('should handle BR inside styled spans', () => {
+		const { container, doc } = createContainer(
+			'M<span class="typost-styled">I</span>LANO<br>TEXT'
+		);
+		const map = buildTextOffsetMap(container, doc);
+
+		// "M" (0-1), "I" (1-2), "LANO" (2-6), BR at 6, "TEXT" (7-11)
+		expect(map).toHaveLength(4);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 1, text: 'M' }));
+		expect(map[1]).toEqual(expect.objectContaining({ start: 1, end: 2, text: 'I' }));
+		expect(map[2]).toEqual(expect.objectContaining({ start: 2, end: 6, text: 'LANO' }));
+		expect(map[3]).toEqual(expect.objectContaining({ start: 7, end: 11, text: 'TEXT' }));
+	});
+
+	it('should handle content with no BRs unchanged', () => {
+		const { container, doc } = createContainer('Simple text');
+		const map = buildTextOffsetMap(container, doc);
+
+		expect(map).toHaveLength(1);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 11, text: 'Simple text' }));
+	});
+
+	it('should handle BR with data-rich-text-line-break attribute', () => {
+		const { container, doc } = createContainer(
+			'Line1<br data-rich-text-line-break="true">Line2'
+		);
+		const map = buildTextOffsetMap(container, doc);
+
+		expect(map).toHaveLength(2);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 5, text: 'Line1' }));
+		expect(map[1]).toEqual(expect.objectContaining({ start: 6, end: 11, text: 'Line2' }));
+	});
+
+	it('should not produce map entries for BR elements', () => {
+		const { container, doc } = createContainer('A<br>B');
+		const map = buildTextOffsetMap(container, doc);
+
+		// Only text nodes should be in the map, not BR elements
+		expect(map).toHaveLength(2);
+		map.forEach(entry => {
+			expect(entry.node.nodeType).toBe(Node.TEXT_NODE);
+		});
+	});
+
+	it('should handle consecutive BRs', () => {
+		const { container, doc } = createContainer('A<br><br>B');
+		const map = buildTextOffsetMap(container, doc);
+
+		expect(map).toHaveLength(2);
+		expect(map[0]).toEqual(expect.objectContaining({ start: 0, end: 1, text: 'A' }));
+		// Two BRs at positions 1 and 2, so B starts at 3
+		expect(map[1]).toEqual(expect.objectContaining({ start: 3, end: 4, text: 'B' }));
+	});
+});
+
+describe('getEffectiveTextLength - BR handling', () => {
+
+	it('should return 1 for BR elements', () => {
+		const br = document.createElement('br');
+		expect(getEffectiveTextLength(br)).toBe(1);
+	});
+
+	it('should return text length for text nodes', () => {
+		const text = document.createTextNode('Hello');
+		expect(getEffectiveTextLength(text)).toBe(5);
+	});
+
+	it('should count BR inside element children', () => {
+		const div = document.createElement('div');
+		div.innerHTML = 'Hello<br>World';
+		// "Hello" (5) + BR (1) + "World" (5) = 11
+		expect(getEffectiveTextLength(div)).toBe(11);
+	});
+
+	it('should count nested BRs recursively', () => {
+		const div = document.createElement('div');
+		div.innerHTML = '<span>A<br>B</span>';
+		// "A" (1) + BR (1) + "B" (1) = 3
+		expect(getEffectiveTextLength(div)).toBe(3);
+	});
+});
+
+describe('parseInlineFeaturesAtCursor - BR offset handling', () => {
+
+	it('should correctly detect features after a BR', () => {
+		const html = 'MILANO CORTINA<br><span class="typost-styled" data-features="ss01">M</span>ILANO CORTINA';
+		// "MILANO CORTINA" (0-14), BR at 14, "M" span starts at 15
+		const result = parseInlineFeaturesAtCursor(html, 15, 15);
+		expect(result).toEqual(['ss01']);
+	});
+
+	it('should correctly detect features before a BR', () => {
+		const html = '<span class="typost-styled" data-features="ss02">A</span><br>NEXT LINE';
+		// "A" span at offset 0-1, cursor at 0
+		const result = parseInlineFeaturesAtCursor(html, 0, 0);
+		expect(result).toEqual(['ss02']);
+	});
+
+	it('should return empty array for unstyled text after BR', () => {
+		const html = 'Line1<br>Line2';
+		const result = parseInlineFeaturesAtCursor(html, 6, 6);
+		expect(result).toEqual([]);
+	});
+});
+
+describe('parseInlineStylesAtCursor - BR offset handling', () => {
+
+	it('should detect inline styles after a BR', () => {
+		const html = 'Line1<br><span class="typost-styled" data-features="liga" data-font-id="5" style="font-feature-settings: &quot;liga&quot; 1">Line2</span>';
+		// "Line1" (0-5), BR at 5, "Line2" (6-11)
+		const result = parseInlineStylesAtCursor(html, 6, 6);
+		expect(result).not.toBeNull();
+		expect(result.features).toEqual(['liga']);
+		expect(result.fontId).toBe('5');
+	});
+});
+
+describe('applyStylingSafeStringMethod - BR offset handling', () => {
+
+	it('should apply styling to correct text after BR (the original bug)', () => {
+		const html = '<span class="typost-styled" data-features="ss01" style="font-feature-settings: &quot;ss01&quot; 1">M</span>ILANO CORTIN<span class="typost-styled" data-features="ss02" style="font-feature-settings: &quot;ss02&quot; 1">A</span><br>MILANO CORTINA';
+		// "M"(0-1) "ILANO CORTIN"(1-13) "A"(13-14) BR(14) "MILANO CORTINA"(15-29)
+		// Select "M" on line 2 at offset 15-16
+		const result = applyStylingSafeStringMethod(
+			html, 15, 16,
+			{ 'data-features': 'ss01' },
+			'font-feature-settings: "ss01" 1'
+		);
+
+		expect(result.success).toBe(true);
+		// The "M" after <br> should be wrapped, not the "I"
+		expect(result.content).toMatch(/<br><span[^>]*data-features="ss01"[^>]*>M<\/span>ILANO CORTINA/);
+	});
+
+	it('should apply styling to correct text with multiple BRs', () => {
+		const html = 'Line1<br>Line2<br>Line3';
+		// "Line1"(0-5) BR(5) "Line2"(6-11) BR(11) "Line3"(12-17)
+		const result = applyStylingSafeStringMethod(
+			html, 12, 17,
+			{ 'data-features': 'liga' },
+			'font-feature-settings: "liga" 1'
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.content).toMatch(/<span[^>]*data-features="liga"[^>]*>Line3<\/span>/);
+	});
+
+	it('should apply styling to text on first line (no BR offset impact)', () => {
+		const html = 'HELLO<br>WORLD';
+		// Select "HELLO" at offset 0-5
+		const result = applyStylingSafeStringMethod(
+			html, 0, 5,
+			{ 'data-features': 'ss01' },
+			'font-feature-settings: "ss01" 1'
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.content).toMatch(/<span[^>]*data-features="ss01"[^>]*>HELLO<\/span><br>WORLD/);
+	});
+
+	it('should apply styling spanning across a BR', () => {
+		const html = 'AB<br>CD';
+		// "AB"(0-2) BR(2) "CD"(3-5)
+		// Select from offset 1 to 4 ("B" + BR + "C")
+		const result = applyStylingSafeStringMethod(
+			html, 1, 4,
+			{ 'data-features': 'ss01' },
+			'font-feature-settings: "ss01" 1'
+		);
+
+		expect(result.success).toBe(true);
+		// Should wrap both text portions around the BR
+		expect(result.content).toContain('data-features="ss01"');
+	});
+});

--- a/blocks/typography-stylist/edit.js
+++ b/blocks/typography-stylist/edit.js
@@ -29,7 +29,7 @@ import {
 import { useState, useRef, useEffect, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { create, slice as sliceRichText, getTextContent } from '@wordpress/rich-text';
-import { parseInlineStylesAtCursor, updateSpanPropertyInPlace, splitSpanAndApply, detectBlockComputedFont, applyOrMergeStyling, validateRangeMatchesSelection, applyStylingSafeStringMethod, isValidFontSizeRange, debounce, removePropertyFromSelection } from './utils';
+import { buildTextOffsetMap, parseInlineStylesAtCursor, updateSpanPropertyInPlace, splitSpanAndApply, detectBlockComputedFont, applyOrMergeStyling, validateRangeMatchesSelection, applyStylingSafeStringMethod, isValidFontSizeRange, debounce, removePropertyFromSelection } from './utils';
 import { calculateResize } from '../../assets/js/modal-drag-resize';
 
 // Viewport breakpoints for responsive font sizing
@@ -265,30 +265,25 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 	const inlineFontFamilyAtSelection = inlineStylesAtSelection?.fontId || null;
 
 	// Helper to create a Range for the given linear text offsets within a container
+	// Uses buildTextOffsetMap to account for <br> line breaks in offset calculations
 	const getRangeForOffsets = (rootNode, startOffset, endOffset, docContext) => {
-		let currentOffset = 0;
-		const walker = document.createTreeWalker(rootNode, NodeFilter.SHOW_TEXT);
-		let textNode;
+		const textMap = buildTextOffsetMap(rootNode, document);
 		let rangeStartNode = null;
 		let rangeStartOffset = 0;
 		let rangeEndNode = null;
 		let rangeEndOffset = 0;
 
-		while ((textNode = walker.nextNode())) {
-			const nodeLength = textNode.nodeValue.length;
-
-			if (currentOffset + nodeLength > startOffset && !rangeStartNode) {
-				rangeStartNode = textNode;
-				rangeStartOffset = startOffset - currentOffset;
+		for (const entry of textMap) {
+			if (entry.end > startOffset && !rangeStartNode) {
+				rangeStartNode = entry.node;
+				rangeStartOffset = startOffset - entry.start;
 			}
 
-			if (currentOffset + nodeLength >= endOffset && !rangeEndNode) {
-				rangeEndNode = textNode;
-				rangeEndOffset = endOffset - currentOffset;
+			if (entry.end >= endOffset && !rangeEndNode) {
+				rangeEndNode = entry.node;
+				rangeEndOffset = endOffset - entry.start;
 				break;
 			}
-
-			currentOffset += nodeLength;
 		}
 
 		if (!rangeStartNode || !rangeEndNode) {

--- a/blocks/typography-stylist/edit.js
+++ b/blocks/typography-stylist/edit.js
@@ -2293,7 +2293,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 											variant="secondary"
 											onClick={resetFontFamily}
 											isDestructive
-											style={{ marginTop: '8px', float: 'right', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+											style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
 											icon="undo"
 										>
 											{__('Reset Font Family', 'typography-stylist')}
@@ -2330,7 +2330,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 											variant="secondary"
 											onClick={resetFontWeight}
 											isDestructive
-											style={{ marginTop: '8px', float: 'right', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+											style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
 											icon="undo"
 										>
 											{__('Reset Font Weight', 'typography-stylist')}
@@ -2395,7 +2395,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 												variant="secondary"
 												onClick={resetFontSize}
 												isDestructive
-												style={{ marginTop: '8px', float: 'right', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+												style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
 												icon="undo"
 											>
 												{__('Reset Font Size', 'typography-stylist')}
@@ -2431,7 +2431,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 											variant="secondary"
 											onClick={clearLineHeight}
 											isDestructive
-											style={{ marginTop: '8px', float: 'right', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+											style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
 											icon="undo"
 										>
 											{__('Clear', 'typography-stylist')}
@@ -2462,7 +2462,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 											variant="secondary"
 											onClick={clearLetterSpacing}
 											isDestructive
-											style={{ marginTop: '8px', float: 'right', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+											style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
 											icon="undo"
 											isSmall
 										>

--- a/blocks/typography-stylist/utils.js
+++ b/blocks/typography-stylist/utils.js
@@ -6,6 +6,88 @@
  */
 
 /**
+ * Build a text offset map from a DOM container, accounting for <br> elements.
+ *
+ * Designed to match WordPress RichText's offset system, where each <br> element
+ * (inserted via Shift+Enter) counts as 1 character position. Without this adjustment,
+ * offsets from wp.data selectionStart.offset / selectionEnd.offset would be misaligned
+ * with text node positions, causing styles to be applied to the wrong character.
+ *
+ * Returns only text node entries — <br> elements increment the running offset by 1
+ * but do not produce entries in the returned array, since they cannot be split or
+ * wrapped in <span> elements. Callers iterate the returned entries to find or wrap
+ * text at a given offset range.
+ *
+ * @param {Node} container - DOM node to walk
+ * @param {Document} docContext - Document context for creating the TreeWalker
+ * @return {Array<{node: Node, start: number, end: number, text: string}>} Text node map with BR-adjusted offsets
+ */
+export function buildTextOffsetMap(container, docContext) {
+	const walker = docContext.createTreeWalker(
+		container,
+		NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+		{
+			acceptNode: function (node) {
+				if (node.nodeType === Node.TEXT_NODE) {
+					return NodeFilter.FILTER_ACCEPT;
+				}
+				if (node.nodeName === 'BR') {
+					return NodeFilter.FILTER_ACCEPT;
+				}
+				// Skip other elements but still visit their children
+				return NodeFilter.FILTER_SKIP;
+			}
+		}
+	);
+
+	const map = [];
+	let currentOffset = 0;
+	let node;
+
+	while ((node = walker.nextNode())) {
+		if (node.nodeType === Node.TEXT_NODE) {
+			const text = node.nodeValue || '';
+			map.push({
+				node: node,
+				start: currentOffset,
+				end: currentOffset + text.length,
+				text: text
+			});
+			currentOffset += text.length;
+		} else if (node.nodeName === 'BR') {
+			// BR counts as 1 character position to match WordPress RichText offsets
+			currentOffset += 1;
+		}
+	}
+
+	return map;
+}
+
+/**
+ * Get the effective text length of a DOM node, counting <br> elements as 1 character.
+ *
+ * Unlike node.textContent.length which returns 0 for <br> elements,
+ * this function counts each <br> as 1 character position to match
+ * WordPress RichText's offset system.
+ *
+ * @param {Node} node - DOM node to measure
+ * @return {number} Effective text length including BR characters
+ */
+export function getEffectiveTextLength(node) {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return (node.textContent || '').length;
+	}
+	if (node.nodeName === 'BR') {
+		return 1;
+	}
+	let length = 0;
+	for (let i = 0; i < node.childNodes.length; i++) {
+		length += getEffectiveTextLength(node.childNodes[i]);
+	}
+	return length;
+}
+
+/**
  * Parse inline features from HTML content at a specific cursor position
  *
  * Finds styled spans in HTML content and extracts OpenType features from the
@@ -31,28 +113,23 @@ export function parseInlineFeaturesAtCursor(htmlContent, cursorStart, cursorEnd)
 	let smallestMatchingSpan = null;
 	let smallestSpanSize = Infinity;
 
+	// Build offset map once, reuse for all spans
+	const textNodeMap = buildTextOffsetMap(container, doc);
+
 	for (const span of styledSpans) {
-		// Find this span's position in the text
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+		// Find this span's position in the text using pre-built map
 		let spanStart = 0;
 		let spanEnd = 0;
 		let found = false;
-		let offset = 0;
 
-		let node;
-		while ((node = walker.nextNode())) {
-			const nodeLength = node.nodeValue.length;
-
-			// Check if this text node is inside our span
-			if (span.contains(node)) {
+		for (const entry of textNodeMap) {
+			if (span.contains(entry.node)) {
 				if (!found) {
-					spanStart = offset;
+					spanStart = entry.start;
 					found = true;
 				}
-				spanEnd = offset + nodeLength;
+				spanEnd = entry.end;
 			}
-
-			offset += nodeLength;
 		}
 
 		// Check if the cursor/selection overlaps with this span
@@ -94,26 +171,19 @@ export function parseInlineFeaturesAtCursor(htmlContent, cursorStart, cursorEnd)
 	// BUT only include features if cursor is ACTUALLY inside the nested span
 	const nestedStyledSpans = smallestMatchingSpan.querySelectorAll('span.typost-styled');
 	for (const nested of nestedStyledSpans) {
-		// Calculate the text position range for this nested span
-		const nestedWalker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+		// Calculate the text position range for this nested span using pre-built map
 		let nestedStart = 0;
 		let nestedEnd = 0;
 		let nestedFound = false;
-		let nestedOffset = 0;
 
-		let nestedNode;
-		while ((nestedNode = nestedWalker.nextNode())) {
-			const nestedNodeLength = nestedNode.nodeValue.length;
-
-			if (nested.contains(nestedNode)) {
+		for (const entry of textNodeMap) {
+			if (nested.contains(entry.node)) {
 				if (!nestedFound) {
-					nestedStart = nestedOffset;
+					nestedStart = entry.start;
 					nestedFound = true;
 				}
-				nestedEnd = nestedOffset + nestedNodeLength;
+				nestedEnd = entry.end;
 			}
-
-			nestedOffset += nestedNodeLength;
 		}
 
 		// Only include features if cursor is inside this nested span
@@ -212,28 +282,23 @@ export function parseInlineFontFamilyAtCursor(htmlContent, cursorStart, cursorEn
 	let smallestMatchingSpan = null;
 	let smallestSpanSize = Infinity;
 
+	// Build offset map once, reuse for all spans
+	const textNodeMap = buildTextOffsetMap(container, doc);
+
 	for (const span of styledSpans) {
-		// Find this span's position in the text
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+		// Find this span's position in the text using pre-built map
 		let spanStart = 0;
 		let spanEnd = 0;
 		let found = false;
-		let offset = 0;
 
-		let node;
-		while ((node = walker.nextNode())) {
-			const nodeLength = node.nodeValue.length;
-
-			// Check if this text node is inside our span
-			if (span.contains(node)) {
+		for (const entry of textNodeMap) {
+			if (span.contains(entry.node)) {
 				if (!found) {
-					spanStart = offset;
+					spanStart = entry.start;
 					found = true;
 				}
-				spanEnd = offset + nodeLength;
+				spanEnd = entry.end;
 			}
-
-			offset += nodeLength;
 		}
 
 		// Check if the cursor/selection overlaps with this span
@@ -288,22 +353,8 @@ export function parseInlineStylesAtCursor(htmlContent, cursorStart, cursorEnd) {
 			return null;
 		}
 
-		// Build text offset map using TreeWalker
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-		let currentOffset = 0;
-		let textNode;
-		const textNodeMap = [];
-
-		while ((textNode = walker.nextNode())) {
-			const text = textNode.textContent || '';
-			textNodeMap.push({
-				node: textNode,
-				start: currentOffset,
-				end: currentOffset + text.length,
-				text: text
-			});
-			currentOffset += text.length;
-		}
+		// Build text offset map (accounts for <br> line breaks)
+		const textNodeMap = buildTextOffsetMap(container, doc);
 
 		// Find spans that overlap cursor position
 		let smallestMatchingSpan = null;
@@ -493,17 +544,8 @@ export function updateSpanPropertyInPlace(htmlContent, cursorOffset, propertyDat
 			return { success: false, content: htmlContent };
 		}
 
-		// Build text offset map
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-		let currentOffset = 0;
-		let textNode;
-		const textNodeMap = [];
-
-		while ((textNode = walker.nextNode())) {
-			const text = textNode.textContent || '';
-			textNodeMap.push({ node: textNode, start: currentOffset, end: currentOffset + text.length });
-			currentOffset += text.length;
-		}
+		// Build text offset map (accounts for <br> line breaks)
+		const textNodeMap = buildTextOffsetMap(container, doc);
 
 		// Find span at cursor
 		let targetSpan = null;
@@ -582,17 +624,8 @@ export function splitSpanAndApply(htmlContent, startOffset, endOffset, propertyD
 			return { success: false, content: htmlContent };
 		}
 
-		// Build text offset map
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-		let currentOffset = 0;
-		let textNode;
-		const textNodeMap = [];
-
-		while ((textNode = walker.nextNode())) {
-			const text = textNode.textContent || '';
-			textNodeMap.push({ node: textNode, start: currentOffset, end: currentOffset + text.length, text: text });
-			currentOffset += text.length;
-		}
+		// Build text offset map (accounts for <br> line breaks)
+		const textNodeMap = buildTextOffsetMap(container, doc);
 
 		// Find parent span that has the property and overlaps selection
 		let parentSpan = null;
@@ -677,6 +710,20 @@ export function splitSpanAndApply(htmlContent, startOffset, endOffset, propertyD
 		let currentPos = 0;
 		const segments = { before: [], selection: [], after: [] };
 
+		// Classify an atomic (unsplittable) node into a segment by its position
+		function classifyAtomicNode(html, nodeStart, nodeLength) {
+			const nodeEnd = nodeStart + nodeLength;
+			if (nodeEnd <= selStart) {
+				segments.before.push(html);
+			} else if (nodeStart >= selEnd) {
+				segments.after.push(html);
+			} else if (nodeStart >= selStart && nodeEnd <= selEnd) {
+				segments.selection.push(html);
+			}
+			// If node spans boundaries, it was already rejected by boundary check
+			currentPos += nodeLength;
+		}
+
 		function processNode(node) {
 			if (node.nodeType === Node.TEXT_NODE) {
 				const text = node.textContent || '';
@@ -705,23 +752,10 @@ export function splitSpanAndApply(htmlContent, startOffset, endOffset, propertyD
 					}
 				}
 				currentPos += text.length;
+			} else if (node.nodeName === 'BR') {
+				classifyAtomicNode(node.outerHTML, currentPos, 1);
 			} else if (node.nodeType === Node.ELEMENT_NODE) {
-				const childStart = currentPos;
-				const childText = node.textContent || '';
-				const childEnd = childStart + childText.length;
-
-				// Determine which segment this entire child element belongs to
-				if (childEnd <= selStart) {
-					segments.before.push(node.outerHTML);
-					currentPos += childText.length;
-				} else if (childStart >= selEnd) {
-					segments.after.push(node.outerHTML);
-					currentPos += childText.length;
-				} else if (childStart >= selStart && childEnd <= selEnd) {
-					segments.selection.push(node.outerHTML);
-					currentPos += childText.length;
-				}
-				// If child spans boundaries, it was already rejected by boundary check
+				classifyAtomicNode(node.outerHTML, currentPos, getEffectiveTextLength(node));
 			}
 		}
 
@@ -1042,22 +1076,8 @@ export function applyStylingSafeStringMethod(htmlContent, startOffset, endOffset
 		const doc = parser.parseFromString(`<div>${htmlContent}</div>`, 'text/html');
 		const container = doc.body.firstChild;
 
-		// Build text position map
-		const textMap = [];
-		let currentOffset = 0;
-		const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-		let textNode;
-
-		while ((textNode = walker.nextNode())) {
-			const nodeText = textNode.nodeValue;
-			textMap.push({
-				node: textNode,
-				start: currentOffset,
-				end: currentOffset + nodeText.length,
-				text: nodeText
-			});
-			currentOffset += nodeText.length;
-		}
+		// Build text position map (accounts for <br> line breaks)
+		const textMap = buildTextOffsetMap(container, doc);
 
 		// Find affected text nodes
 		const affectedNodes = textMap.filter(item =>
@@ -1628,22 +1648,16 @@ export function removePropertyFromSelection(htmlContent, startOffset, endOffset,
 	const doc = parser.parseFromString(`<div>${htmlContent}</div>`, 'text/html');
 	const container = doc.body.firstChild;
 
-	// Build text offset map using TreeWalker to find spans at selection
-	const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-	let currentOffset = 0;
-	let textNode;
+	// Build text offset map (accounts for <br> line breaks)
+	const textNodeMap = buildTextOffsetMap(container, doc);
 	const spansAtSelection = new Set();
 
-	// Walk through all text nodes and find spans that overlap with selection
-	while ((textNode = walker.nextNode())) {
-		const textLength = textNode.length;
-		const nodeStart = currentOffset;
-		const nodeEnd = currentOffset + textLength;
-
+	// Walk through text nodes and find spans that overlap with selection
+	for (const entry of textNodeMap) {
 		// Check if this text node overlaps with selection
-		if (nodeEnd > startOffset && nodeStart < endOffset) {
+		if (entry.end > startOffset && entry.start < endOffset) {
 			// Find typost-styled spans containing this text node
-			let parent = textNode.parentElement;
+			let parent = entry.node.parentElement;
 			while (parent && parent !== container) {
 				if (parent.classList && parent.classList.contains('typost-styled')) {
 					if (parent.getAttribute(dataAttribute)) {
@@ -1653,8 +1667,6 @@ export function removePropertyFromSelection(htmlContent, startOffset, endOffset,
 				parent = parent.parentElement;
 			}
 		}
-
-		currentOffset += textLength;
 	}
 
 	// Remove property from each span found in selection
@@ -1679,6 +1691,7 @@ export function removePropertyFromSelection(htmlContent, startOffset, endOffset,
 // Expose utility functions for cross-module use (block-editor.js uses CommonJS/Browserify)
 if (typeof window !== 'undefined') {
 	window.typostSharedUtils = {
+		buildTextOffsetMap,
 		parseInlineStylesAtCursor,
 		parseInlineFeaturesAtCursor,
 		parseInlineFontFamilyAtCursor

--- a/todo/refactor-style-string-helpers.md
+++ b/todo/refactor-style-string-helpers.md
@@ -1,0 +1,130 @@
+# Refactor: Extract `parseStyleString` / `buildStyleString` Helpers
+
+## Problem
+
+The pattern for parsing CSS style strings into objects and building them back appears 7+ times across `blocks/typography-stylist/utils.js`:
+
+```js
+// Parse (7 sites)
+existingStyle.split(';').forEach(rule => {
+    const [prop, val] = rule.split(':').map(s => s.trim());
+    if (prop && val) styleObj[prop] = val;
+});
+
+// Build (5 sites)
+Object.entries(styleObj).map(([p, v]) => `${p}: ${v}`).join('; ');
+```
+
+## Proposed Functions
+
+```js
+/**
+ * Parse a CSS style string into a property-value object.
+ * @param {string} styleString - CSS style string (e.g., "font-size: 20px; font-weight: 700")
+ * @return {Object} Property-value map (e.g., { 'font-size': '20px', 'font-weight': '700' })
+ */
+export function parseStyleString(styleString) { ... }
+
+/**
+ * Build a CSS style string from a property-value object.
+ * @param {Object} styleObj - Property-value map
+ * @return {string} CSS style string
+ */
+export function buildStyleString(styleObj) { ... }
+```
+
+## Affected Call Sites
+
+### Parse sites (`split(';')` pattern)
+
+| Line | Function | Notes |
+|------|----------|-------|
+| ~591 | `updateSpanPropertyInPlace` | Standard usage |
+| ~692 | `splitSpanAndApply` | Parses parent span styles |
+| ~700 | `splitSpanAndApply` | Parses new style string |
+| ~932 | `applyOrMergeStyling` | Parses existing span styles |
+| ~950 | `applyOrMergeStyling` | Parses new style string |
+| ~1160 | `applyStylingSafeStringMethod` | Parses existing span styles |
+| ~1177 | `applyStylingSafeStringMethod` | Parses new style string |
+| ~1596 | `removeSpanProperty` | **Variation:** filters out a specific property during parse. Keep filter in caller: `delete result[styleProperty]` |
+
+### Build sites (`.join('; ')` pattern)
+
+| Line | Function |
+|------|----------|
+| ~596 | `updateSpanPropertyInPlace` |
+| ~705 | `splitSpanAndApply` |
+| ~984 | `applyOrMergeStyling` |
+| ~1210 | `applyStylingSafeStringMethod` |
+| ~1607 | `removeSpanProperty` |
+
+## Gotcha: Line ~1596 Variation
+
+One call site filters out a property during parsing:
+
+```js
+if (prop && value && prop !== styleProperty) { ... }
+```
+
+The extracted `parseStyleString` must return **all** properties. The caller handles removal:
+
+```js
+const styleObj = parseStyleString(currentStyle);
+delete styleObj[styleProperty];
+```
+
+## Test Plan
+
+### `parseStyleString` Tests
+
+```js
+describe('parseStyleString', () => {
+    // Basic parsing
+    it('should parse single property');
+    it('should parse multiple properties');
+
+    // Whitespace handling
+    it('should handle no spaces around colon');
+    it('should handle extra whitespace');
+    it('should handle trailing semicolon');
+
+    // Plugin-specific CSS values
+    it('should parse font-feature-settings with multiple features');
+    //   "font-feature-settings: \"ss01\" 1, \"ss02\" 1"
+    //   split(':') produces ['font-feature-settings', ' "ss01" 1, "ss02" 1']
+    //   Safe because font-feature-settings values don't contain colons.
+    it('should parse font-family with CSS variable: var(--font-12)');
+    it('should parse a full Typography Stylist style string');
+
+    // Edge cases
+    it('should return empty object for empty string');
+    it('should return empty object for null/undefined');
+    it('should skip malformed rules with no colon');
+    it('should include all properties without filtering');
+});
+```
+
+### `buildStyleString` Tests
+
+```js
+describe('buildStyleString', () => {
+    it('should build single property');
+    it('should build multiple properties separated by "; "');
+    it('should handle empty object');
+
+    // Round-trip stability
+    it('should round-trip through parse then build');
+    it('should round-trip font-feature-settings');
+});
+```
+
+### Verification After Implementation
+
+1. `npm test` -- all existing 271+ tests must still pass (they exercise style parsing indirectly)
+2. Add the new unit tests above
+3. `npm run build`
+4. `npm test` again post-build
+
+## Risk Assessment
+
+**Low risk.** The parse/build logic is identical across all call sites with one documented exception (the filter at line ~1596). Existing integration tests in `applyStylingSafeStringMethod.test.js`, `splitSpanAndApply.test.js`, `updateSpanPropertyInPlace.test.js`, and `parseInlineStylesAtCursor.test.js` all exercise style parsing indirectly and will catch regressions.


### PR DESCRIPTION
Closes #86 , closes #100 

This pull request introduces robust handling of `<br>` (line break) elements in text offset calculations for the Typography Stylist block, ensuring that styling and selections match WordPress RichText's offset system. The main focus is on accurately mapping text positions and applying styles when content includes hard line breaks, fixing previous bugs where styling could be misapplied after `<br>` tags. The update includes new utility functions, test coverage, and integration into the block's editing logic.

**Key changes:**

### Core logic improvements

* Added a new `buildTextOffsetMap` utility function in `utils.js` to generate a mapping of text node positions that treats each `<br>` as a single character offset, matching WordPress RichText's behavior. This ensures that styling and selection offsets are accurate even with line breaks.
* Introduced `getEffectiveTextLength` in `utils.js`, which recursively counts text length in a DOM node, treating `<br>` as one character, for consistent offset calculations.

### Integration into block editor

* Updated `block-editor.js` to use `buildTextOffsetMap` for all offset calculations involving styled spans and text selections, replacing previous logic that did not account for `<br>` elements. This change ensures selections and style applications are correctly aligned with user expectations. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R96-R150) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R387-L354) [[3]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1039-L1060)
* Modified `edit.js` to import and use `buildTextOffsetMap` in the `getRangeForOffsets` helper, ensuring all range calculations in the editor panel handle `<br>` offsets properly. [[1]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL32-R32) [[2]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cR268-L291)

### Testing and validation

* Added a comprehensive test suite in `__tests__/br-offset.test.js` to verify correct handling of `<br>` elements in offset mapping, text length calculation, feature/style parsing at the cursor, and styling application. These tests cover edge cases such as consecutive `<br>`s, styled spans, and selections spanning line breaks.

### UI adjustments

* Removed unnecessary `float: right` styling from reset/clear buttons in the editor's sidebar for improved layout consistency. [[1]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL2296-R2291) [[2]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL2333-R2328) [[3]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL2398-R2393) [[4]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL2434-R2429) [[5]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL2465-R2460)

### Miscellaneous

* Updated `.npmignore` to exclude the `todo/` directory.

These changes collectively resolve issues with misaligned styling and selection when editing text with line breaks and provide a solid foundation for further rich text improvements.