### PR TITLE
chore: Bump version to 1.2.0 in package.json, package-lock.json, read…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "typost",
-      "version": "1.1.9",
+      "version": "1.2.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/cli": "^7.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typost",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "WordPress plugin for advanced OpenType typography features in Gutenberg headlines",
   "scripts": {
     "build": "npm run build:block && npm run build:js && npm run build:css",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matthewneilcowan
 Tags: typography, opentype, ligatures, stylistic-sets, webfonts
 Requires at least: 5.8
 Tested up to: 6.9.1
-Stable tag: 1.1.9
+Stable tag: 1.2.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -3,7 +3,7 @@
  * Plugin Name: Typography Stylist
  * Plugin URI: https://wordpress.org/plugins/typography-stylist/
  * Description: Add advanced OpenType features (ligatures, stylistic sets, swashes) to headlines with inline text selection and live preview.
- * Version: 1.1.9
+ * Version: 1.2.0
  * Author: Matthew Cowan
  * Author URI: https://mnc4.com
  * License: GPL v2 or later
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 
 // Define plugin constants (check if already defined for test compatibility)
 if (!defined('TYPOST_VERSION')) {
-    define('TYPOST_VERSION', '1.1.9');
+    define('TYPOST_VERSION', '1.2.0');
 }
 if (!defined('TYPOST_PLUGIN_DIR')) {
     define('TYPOST_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
…me.txt, and typography-stylist.php

This pull request updates the plugin version from 1.1.9 to 1.2.0 across all relevant files. The changes are primarily focused on version bumping to ensure consistency throughout the project.

Version updates:

* Updated the plugin version in `package.json`, `readme.txt`, and `typography-stylist.php` to 1.2.0. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-8477ec8a3f90e1acada6ac3df511bfaf7e7b3e9ee35435851a2affcbd939737cL6-R6)
* Changed the `TYPOST_VERSION` constant in `typography-stylist.php` to reflect the new version.