### PR TITLE
Bugfix/#97 apply anyway

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -250,10 +250,9 @@ If you select partial words (like just "Sa" in "Sarah"), you'll see an accessibi
 
 > "Warning: Partial word selection detected. This may fragment text for screen readers."
 
-You have three options:
-- **Convert to Accessible Block** - Converts to an Typography Stylist block (recommended)
-- **Apply Anyway** - Applies the format but may impact accessibility
-- **Cancel** - Cancels the operation
+You have two options:
+- **Convert to Typography Stylist Block** - Converts to an accessible Typography Stylist block (recommended)
+- **Discard Changes** - Cancels the operation
 
 **Why this matters:** Screen readers may read fragmented text in a confusing way. the Typography Stylist block solves this with dual content.
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ font-family: 'Playfair Display', Georgia, serif;
 7. **Click Apply** to save
 
 **Note:** If you select partial words, you'll see an accessibility warning with options to:
-- Convert to an accessible Typost block
-- Apply anyway (not recommended)
-- Cancel
+- Convert to an accessible Typography Stylist block (recommended)
+- Discard changes
 
 #### Method 2: Typography Stylist Block (for complex typography)
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ## Changelog
 
+### Version 1.2.1
+
+**Accessibility Enforcement:**
+- **Removed: "Apply Anyway" option** - The accessibility warning when selecting partial words in rich text blocks no longer offers a bypass. Users must either convert to a Typography Stylist block (which provides accessible dual-content markup) or discard their changes. This reinforces the plugin's accessibility-first approach.
+- **Changed: "Cancel" renamed to "Discard Changes"** - Clearer labeling for the action that dismisses the warning without applying styles.
+
 ### Version 1.2.0
 
 **Quick Features Toggle Auto-Apply & UX Improvements:**

--- a/assets/css/admin-page.css
+++ b/assets/css/admin-page.css
@@ -54,6 +54,7 @@
 
 .typost-tab-content.active {
     display: block;
+    background: #FAF9F6;
 }
 
 .typost-preset-controls {
@@ -1083,7 +1084,7 @@
 /* Developer Support Section */
 .typost-developer-support {
     margin-top: 30px;
-    background: #fff;
+    background: #fffff0;
     border: 1px solid #c3c4c7;
     box-shadow: 0 1px 1px rgba(0,0,0,.04);
     padding: 20px;

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -334,7 +334,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             this.setPreviewDevice = this.setPreviewDevice.bind(this);
             this.validateSelection = this.validateSelection.bind(this);
             this.convertToBlock = this.convertToBlock.bind(this);
-            this.applyFeaturesForce = this.applyFeaturesForce.bind(this);
+
             this.applyFeatureFromPreview = this.applyFeatureFromPreview.bind(this);
             this.undoLastChange = this.undoLastChange.bind(this);
             this.saveToHistory = this.saveToHistory.bind(this);
@@ -993,7 +993,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             if (breaksWordStart || breaksWordEnd) {
                 return {
                     valid: false,
-                    message: __('For better accessibility, select complete words or phrases. Or convert to a Typography Stylist block for accessible styling of partial words.', 'typography-stylist')
+                    message: __('For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words.', 'typography-stylist')
                 };
             }
 
@@ -1319,83 +1319,6 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             this.setState({ isOpen: false, hasChanges: false });
         }
 
-        /**
-         * Apply features without validation (force apply)
-         */
-        applyFeaturesForce() {
-            const { value, onChange } = this.props;
-            const { selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight } = this.state;
-
-            if (selectedFeatures.length === 0 && !selectedFont && fontSize === 'inherit' && fontWeight === '400' && letterSpacing === 0 && lineHeight === 0) {
-                onChange(removeFormat(value, FORMAT_TYPE));
-            } else {
-                const attributes = {};
-                let styleString = '';
-
-                if (selectedFeatures.length > 0) {
-                    const cssValue = this.featuresToCSS(selectedFeatures);
-                    attributes['data-features'] = selectedFeatures.join(',');
-                    styleString += `font-feature-settings: ${cssValue}`;
-                }
-
-                // Add font family - use CSS variable if fontId is available
-                if (selectedFontId) {
-                    attributes['data-font'] = selectedFont;
-                    attributes['data-font-id'] = String(selectedFontId);
-                    if (styleString) styleString += '; ';
-                    styleString += `font-family: var(--font-${selectedFontId})`;
-                } else if (selectedFont) {
-                    attributes['data-font'] = selectedFont;
-                    if (styleString) styleString += '; ';
-                    styleString += `font-family: ${selectedFont}`;
-                }
-
-                attributes['data-fontweight'] = fontWeight;
-                if (styleString) styleString += '; ';
-                styleString += `font-weight: ${fontWeight}`;
-
-                if (letterSpacing !== 0) {
-                    attributes['data-letterspacing'] = letterSpacing.toString();
-                    if (styleString) styleString += '; ';
-                    styleString += `letter-spacing: ${letterSpacing / 1000}em`;
-                }
-
-                if (lineHeight !== 0) {
-                    attributes['data-lineheight'] = lineHeight.toString();
-                    if (styleString) styleString += '; ';
-                    styleString += `line-height: ${lineHeight}`;
-                }
-
-                if (fontSize !== 'inherit') {
-                    attributes['data-fontsize'] = fontSize;
-                    attributes['data-fontsize-min'] = fontSizeMin.toString();
-                    attributes['data-fontsize-preferred'] = fontSizePreferred.toString();
-                    attributes['data-fontsize-max'] = fontSizeMax.toString();
-
-                    if (styleString) styleString += '; ';
-                    styleString += `font-size: clamp(${fontSizeMin}px, ${fontSizePreferred / 16}rem + ${((fontSizeMax - fontSizeMin) / (RESPONSIVE_FONT_MAX_VIEWPORT - RESPONSIVE_FONT_MIN_VIEWPORT)) * 100}vw, ${fontSizeMax}px)`;
-                }
-
-                attributes['style'] = styleString;
-
-                // Add aria-label if enabled for accessibility (in force apply)
-                if (typostData.enableAriaLabels && value) {
-                    const selectedText = value.start !== value.end
-                        ? getTextContent(slice(value, value.start, value.end))
-                        : getTextContent(value);
-                    if (selectedText) {
-                        attributes['aria-label'] = selectedText;
-                    }
-                }
-
-                onChange(applyFormat(value, {
-                    type: FORMAT_TYPE,
-                    attributes: attributes
-                }));
-            }
-
-            this.setState({ isOpen: false, hasChanges: false });
-        }
 
         /**
          * Apply preset
@@ -2215,19 +2138,9 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                             </Button>
                                             <Button
                                                 isSecondary
-                                                onClick={() => {
-                                                    this.setState({ showAccessibilityWarning: false });
-                                                    // Apply anyway - bypass validation
-                                                    this.applyFeaturesForce();
-                                                }}
-                                            >
-                                                {__('Apply Anyway', 'typography-stylist')}
-                                            </Button>
-                                            <Button
-                                                isTertiary
                                                 onClick={() => this.setState({ showAccessibilityWarning: false })}
                                             >
-                                                {__('Cancel', 'typography-stylist')}
+                                                {__('Discard Changes', 'typography-stylist')}
                                             </Button>
                                         </ButtonGroup>
                                     </div>

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -883,16 +883,16 @@ msgid "Typography Stylist"
 msgstr "Estilista OpenType"
 
 #: assets/js/block-editor.js:356
-msgid "For better accessibility, select complete words or phrases. Or convert to a Typography Stylist block for accessible styling of partial words."
-msgstr "Para mejor accesibilidad, selecciona palabras o frases completas. O conviértelo a un bloque Estilista OpenType para estilizar palabras parciales de forma accesible."
+msgid "For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words."
+msgstr "Para mejor accesibilidad, selecciona palabras o frases completas, o conviértelo a un bloque Estilista OpenType para estilizar palabras parciales de forma accesible."
 
 #: assets/js/block-editor.js:832
 msgid "Convert to Typography Stylist Block"
 msgstr "Convertir a Bloque Estilista OpenType"
 
 #: assets/js/block-editor.js:842
-msgid "Apply Anyway"
-msgstr "Aplicar de Todas Formas"
+msgid "Discard Changes"
+msgstr "Descartar Cambios"
 
 #: assets/js/block-editor.js:470
 msgid "Font Weight"

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -883,16 +883,16 @@ msgid "Typography Stylist"
 msgstr "Styliste OpenType"
 
 #: assets/js/block-editor.js:356
-msgid "For better accessibility, select complete words or phrases. Or convert to a Typography Stylist block for accessible styling of partial words."
-msgstr "Pour une meilleure accessibilité, sélectionnez des mots ou phrases complètes. Ou convertissez en bloc Typography Stylist pour un style accessible des mots partiels."
+msgid "For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words."
+msgstr "Pour une meilleure accessibilité, sélectionnez des mots ou phrases complètes, ou convertissez en bloc Typography Stylist pour un style accessible des mots partiels."
 
 #: assets/js/block-editor.js:832
 msgid "Convert to Typography Stylist Block"
 msgstr "Convertir en Bloc Styliste OpenType"
 
 #: assets/js/block-editor.js:842
-msgid "Apply Anyway"
-msgstr "Appliquer Quand Même"
+msgid "Discard Changes"
+msgstr "Annuler les Modifications"
 
 #: assets/js/block-editor.js:470
 msgid "Font Weight"

--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 == Changelog ==
 
+= 1.2.1 =
+* Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
+* Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
+
 = 1.2.0 =
 * Fixed: Inline styles applied to wrong character when content contains line breaks (Shift+Enter) - styling the "M" on a second line would incorrectly style the "I" instead, off by one character per line break
 * Fixed: TreeWalker document context bug - TreeWalkers now created from correct document object (DOMParser) preventing cross-context errors

--- a/readme.txt
+++ b/readme.txt
@@ -169,7 +169,7 @@ Yes! For any font source (uploaded, Adobe Fonts, or custom definitions), you can
 
 The plugin includes accessibility features for screen reader compatibility:
 
-* **Inline Format Warnings**: For rich text blocks like headings, the plugin detects when you select partial words (which can fragment text for screen readers) and shows a warning with options to convert to an accessible block or apply anyway
+* **Inline Format Warnings**: For rich text blocks like headings, the plugin detects when you select partial words (which can fragment text for screen readers) and shows a warning with options to convert to an accessible Typography Stylist block or discard changes
 * **Typography Stylist Block**: Custom block designed for complex typography that includes markup with screen reader-accessible text
 * **ARIA Label Support**: Optional setting to add aria-label attributes to inline formatted text (Settings → Typography Stylist → Accessibility)
 * **Screen Reader Classes**: the Typography Stylist block uses configurable classes (visually-hidden, sr-only, or custom) to hide styled text from screen readers while providing clean text as an alternative


### PR DESCRIPTION
Closes #97 

This pull request focuses on strengthening accessibility enforcement in the Typography Stylist plugin by removing the option to bypass accessibility warnings and clarifying user actions. Documentation, UI, translations, and code have all been updated to reflect these changes and reinforce an accessibility-first workflow.

Accessibility enforcement and UX changes:

* Removed the "Apply Anyway" option from accessibility warnings when users select partial words in rich text blocks. Users must now convert to a Typography Stylist block or discard changes, ensuring accessible markup is always used. (`assets/js/block-editor.js`, `README.md`, `DOCUMENTATION.md`, `readme.txt`) [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L2218-R2143) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R144) [[3]](diffhunk://#diff-69ec517a8969877e050ded4995480c9cf5ecfd715abfd48fb01d978cb2fa1c40L253-R255) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L172-R172) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R235-R238) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R353-R358)
* Renamed the "Cancel" button to "Discard Changes" for clearer intent in accessibility warnings. (`assets/js/block-editor.js`, `README.md`, `DOCUMENTATION.md`, `readme.txt`) [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L2218-R2143) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R144) [[3]](diffhunk://#diff-69ec517a8969877e050ded4995480c9cf5ecfd715abfd48fb01d978cb2fa1c40L253-R255) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L172-R172) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R235-R238) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R353-R358)

Codebase updates:

* Removed the `applyFeaturesForce` method and all logic related to bypassing accessibility validation, ensuring that only accessible formatting options are available. (`assets/js/block-editor.js`) ([assets/js/block-editor.jsL1322-L1398](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1322-L1398), F2023bfbL2023R2023)
* Updated accessibility warning messages for clarity and consistency. (`assets/js/block-editor.js`, `languages/typography-stylist-es_ES.po`, `languages/typography-stylist-fr_FR.po`) [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L996-R996) [[2]](diffhunk://#diff-4bb44e9397c121e19584fb21bd6d57806a990e34eaa6b2ee8d269a26b7444e4eL886-R895) [[3]](diffhunk://#diff-0705093c2ed9bdf25756a26fb1f321cb356b38581b585a5b5b02e42c57aec84aL886-R895)

Documentation and translation updates:

* Revised documentation and changelogs to reflect the removal of the bypass option, the new button labeling, and the accessibility-first approach. (`README.md`, `DOCUMENTATION.md`, `readme.txt`, `languages/typography-stylist-es_ES.po`, `languages/typography-stylist-fr_FR.po`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R144) [[2]](diffhunk://#diff-69ec517a8969877e050ded4995480c9cf5ecfd715abfd48fb01d978cb2fa1c40L253-R255) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L172-R172) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R235-R238) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R353-R358) [[6]](diffhunk://#diff-4bb44e9397c121e19584fb21bd6d57806a990e34eaa6b2ee8d269a26b7444e4eL886-R895) [[7]](diffhunk://#diff-0705093c2ed9bdf25756a26fb1f321cb356b38581b585a5b5b02e42c57aec84aL886-R895)

Styling improvements:

* Updated admin page background colors for better visual distinction. (`assets/css/admin-page.css`) [[1]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9R57) [[2]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9L1086-R1087)