### PR TITLE
fix: Replace line breaks with spaces in screen reader text to improve accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ### Version 1.2.1
 
+**Bug Fix:**
+- **Fixed: Screen reader text missing spaces at line breaks** - When using Shift+Enter in Typography Stylist blocks, the visually-hidden screen reader text concatenated words without a space (e.g. "MILANOCORTINA" instead of "MILANO CORTINA"). Line breaks are now replaced with spaces in the accessible text output.
+
 **Accessibility Enforcement:**
 - **Removed: "Apply Anyway" option** - The accessibility warning when selecting partial words in rich text blocks no longer offers a bypass. Users must either convert to a Typography Stylist block (which provides accessible dual-content markup) or discard their changes. This reinforces the plugin's accessibility-first approach.
 - **Changed: "Cancel" renamed to "Discard Changes"** - Clearer labeling for the action that dismisses the warning without applying styles.

--- a/blocks/typography-stylist/__tests__/save.test.js
+++ b/blocks/typography-stylist/__tests__/save.test.js
@@ -238,6 +238,23 @@ describe('Typography Stylist - Save Component (Frontend Rendering)', () => {
 			expect(tree.children[0].children[0]).toBe('Line One Line Two Line Three');
 		});
 
+		it('should replace RichText <br data-rich-text-line-break="true"> tags with spaces in screen reader version', () => {
+			const attributes = {
+				content: 'Line One<br data-rich-text-line-break="true">Line Two',
+				tagName: 'h2',
+				features: [],
+				screenReaderClass: 'visually-hidden',
+				fontSize: 'inherit',
+				fontWeight: '400',
+				letterSpacing: 0
+			};
+
+			const component = create(save({ attributes }));
+			const tree = component.toJSON();
+
+			expect(tree.children[0].children[0]).toBe('Line One Line Two');
+		});
+
 		it('should handle empty content gracefully', () => {
 			const attributes = {
 				content: '',

--- a/blocks/typography-stylist/__tests__/save.test.js
+++ b/blocks/typography-stylist/__tests__/save.test.js
@@ -203,6 +203,41 @@ describe('Typography Stylist - Save Component (Frontend Rendering)', () => {
 			expect(tree.children[0].children[0]).toBe('Nested tags');
 		});
 
+		it('should replace <br> tags with spaces in screen reader version', () => {
+			const attributes = {
+				content: 'MILANO<br>CORTINA',
+				tagName: 'h2',
+				features: [],
+				screenReaderClass: 'visually-hidden',
+				fontSize: 'inherit',
+				fontWeight: '400',
+				letterSpacing: 0
+			};
+
+			const component = create(save({ attributes }));
+			const tree = component.toJSON();
+
+			// Screen reader version should have a space where <br> was
+			expect(tree.children[0].children[0]).toBe('MILANO CORTINA');
+		});
+
+		it('should replace self-closing <br/> tags with spaces in screen reader version', () => {
+			const attributes = {
+				content: 'Line One<br/>Line Two<br />Line Three',
+				tagName: 'h2',
+				features: [],
+				screenReaderClass: 'visually-hidden',
+				fontSize: 'inherit',
+				fontWeight: '400',
+				letterSpacing: 0
+			};
+
+			const component = create(save({ attributes }));
+			const tree = component.toJSON();
+
+			expect(tree.children[0].children[0]).toBe('Line One Line Two Line Three');
+		});
+
 		it('should handle empty content gracefully', () => {
 			const attributes = {
 				content: '',

--- a/blocks/typography-stylist/save.js
+++ b/blocks/typography-stylist/save.js
@@ -67,9 +67,10 @@ export default function save({ attributes }) {
 	const styleString = buildStyle();
 
 	// Get clean text content (strip HTML tags for screen reader version)
-	// Replace <br> tags with spaces first to prevent word concatenation
+	// Replace <br> tags (with or without attributes, including self-closing forms like <br />) with
+	// spaces first to prevent word concatenation before stripping all remaining HTML tags.
 	const cleanText = content
-		.replace(/<br\s*\/?>/gi, ' ')
+		.replace(/<br\b[^>]*>/gi, ' ')
 		.replace(/<[^>]*>/g, '');
 
 	// Parse style string into object

--- a/blocks/typography-stylist/save.js
+++ b/blocks/typography-stylist/save.js
@@ -67,7 +67,10 @@ export default function save({ attributes }) {
 	const styleString = buildStyle();
 
 	// Get clean text content (strip HTML tags for screen reader version)
-	const cleanText = content.replace(/<[^>]*>/g, '');
+	// Replace <br> tags with spaces first to prevent word concatenation
+	const cleanText = content
+		.replace(/<br\s*\/?>/gi, ' ')
+		.replace(/<[^>]*>/g, '');
 
 	// Parse style string into object
 	const styleObj = {};

--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 == Changelog ==
 
 = 1.2.1 =
+* Fixed: Line breaks (Shift+Enter) in Typography Stylist blocks caused words to run together in screen reader text (e.g. "MILANOCORTINA" instead of "MILANO CORTINA")
 * Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
 * Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
 


### PR DESCRIPTION
This pull request addresses an accessibility bug in the Typography Stylist block where line breaks (such as those inserted with Shift+Enter) caused words to run together in the screen reader text. The update ensures that line breaks are replaced with spaces in the accessible text output, improving the experience for users relying on assistive technology. The changes also include new tests to verify this behavior.

Accessibility bug fix:

* The logic in `blocks/typography-stylist/save.js` was updated so that `<br>` tags (including variations like `<br/>` and `<br />`) are replaced with spaces before all HTML tags are stripped when generating the screen reader version of the text. This prevents words from being concatenated in the accessible output.

Testing improvements:

* Added tests in `blocks/typography-stylist/__tests__/save.test.js` to verify that both `<br>` and self-closing `<br/>` tags are correctly replaced with spaces in the screen reader version.

Documentation updates:

* Updated `README.md` to document the bug fix, explaining the issue and its resolution for users.
* Updated `readme.txt` changelog to mention the fix for line breaks in screen reader text.