### PR TITLE
Bugfix/#109 selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,13 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ### Version 1.2.1
 
-**Bug Fix:**
+**Bug Fixes:**
 - **Fixed: Screen reader text missing spaces at line breaks** - When using Shift+Enter in Typography Stylist blocks, the visually-hidden screen reader text concatenated words without a space (e.g. "MILANOCORTINA" instead of "MILANO CORTINA"). Line breaks are now replaced with spaces in the accessible text output.
+- **Fixed: Inline editor modal lost font selection on close/reopen** - Selecting a font family, closing the modal without applying, then reopening and clicking Apply would silently fail. The root cause was `selectedFontId` not being reset in `togglePopover()`, leaving stale state that caused `applyFeatures()` to enter the `removeFormat` branch instead of `applyFormat`.
+- **Fixed: Missing `data-lineheight` in format type registration** - Line-height values were silently dropped when reading back existing formatted content because the attribute wasn't registered with WordPress's `registerFormatType`.
+
+**UX Improvement:**
+- **Improved: Convert-to-block link in apply notice** - The "Click Apply below the preview to confirm changes" notice now includes a "Convert to a Typography Stylist block" link that converts the current block with features applied, guiding users toward the block type that supports real-time preview.
 
 **Accessibility Enforcement:**
 - **Removed: "Apply Anyway" option** - The accessibility warning when selecting partial words in rich text blocks no longer offers a bypass. Users must either convert to a Typography Stylist block (which provides accessible dual-content markup) or discard their changes. This reinforces the plugin's accessibility-first approach.

--- a/assets/css/block-editor.css
+++ b/assets/css/block-editor.css
@@ -52,6 +52,15 @@
     border-radius: 0;
 }
 
+.typost-convert-link.components-button.is-link {
+    font-size: inherit;
+    padding: 0;
+    height: auto;
+    min-height: 0;
+    vertical-align: baseline;
+    text-decoration: underline;
+}
+
 /* Scrollable Content Wrapper */
 .typost-scrollable-content {
     flex: 1;

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -1997,7 +1997,15 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                             className: 'typost-apply-notice'
                                         },
                                             wp.element.createElement('p', { style: { margin: 0 } },
-                                                __('Click "Apply" below the preview to confirm changes.', 'typography-stylist')
+                                                __('Click "Apply" below the preview to confirm changes.', 'typography-stylist'),
+                                                ' ',
+                                                wp.element.createElement(Button, {
+                                                    variant: 'link',
+                                                    onClick: this.convertToBlock,
+                                                    className: 'typost-convert-link'
+                                                }, __('Convert to a Typography Stylist block', 'typography-stylist')),
+                                                ' ',
+                                                __('to see changes in real time.', 'typography-stylist')
                                             )
                                         )}
                                     </div>

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -297,6 +297,9 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 hasChanges: false,
                 // Initial state when popover opens (for comparing on undo)
                 initialState: null,
+                // Saved selection bounds (survive modal focus changes)
+                savedSelectionStart: null,
+                savedSelectionEnd: null,
                 // Modal position and size (for draggable/resizable modal)
                 modalX: 0,
                 modalY: 0,
@@ -743,8 +746,13 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             let detectionFailed = false;
             let capturedInitialState = null;
             let modalPosition = {};
+            let selectionStart = null;
+            let selectionEnd = null;
 
             if (!this.state.isOpen && value) {
+                // Save selection bounds so they survive modal focus changes
+                selectionStart = value.start;
+                selectionEnd = value.end;
                 if (value.start !== value.end) {
                     // There's a selection - extract it
                     const slicedValue = slice(value, value.start, value.end);
@@ -786,6 +794,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 isOpen: !state.isOpen,
                 selectedFeatures: this.getActiveFeatures() || [],
                 selectedFont: this.getActiveFont() || '',
+                selectedFontId: this.getActiveFontId() || 0,
                 fontSize: this.getActiveFontSize() || 'inherit',
                 fontSizeMin: this.getActiveFontSizeMin() || 16,
                 fontSizePreferred: this.getActiveFontSizePreferred() || 24,
@@ -800,6 +809,9 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 initialState: capturedInitialState,
                 // Reset hasChanges when closing popover (discarding unapplied changes)
                 hasChanges: state.isOpen ? false : state.hasChanges,
+                // Save selection bounds when opening, clear when closing
+                savedSelectionStart: !state.isOpen ? selectionStart : null,
+                savedSelectionEnd: !state.isOpen ? selectionEnd : null,
                 // Reset modal position and drag/resize state
                 ...(!state.isOpen && modalPosition),
                 isDragging: false,
@@ -1034,8 +1046,13 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
             let contentForBlock;
 
+            // Use saved selection bounds if current selection was lost due to modal focus
+            const { savedSelectionStart, savedSelectionEnd } = this.state;
+            const effectiveStart = (value.start === value.end && savedSelectionStart !== null) ? savedSelectionStart : value.start;
+            const effectiveEnd = (value.start === value.end && savedSelectionEnd !== null) ? savedSelectionEnd : value.end;
+
             // Check if there's a selection (partial text selected)
-            if (value.start !== value.end) {
+            if (effectiveStart !== effectiveEnd) {
                 // User selected a portion of text - apply styling only to that portion
                 // Use the current block's HTML content to preserve existing spans
                 const existingContent = currentBlock.attributes.content || '';
@@ -1081,7 +1098,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
                     // Validate selection bounds
                     const textLength = container.textContent.length;
-                    const validationResult = validateSelectionBounds(value.start, value.end, textLength);
+                    const validationResult = validateSelectionBounds(effectiveStart, effectiveEnd, textLength);
                     if (!validationResult.valid) {
                         return;
                     }
@@ -1092,14 +1109,14 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     let endNode = null, endOffset = 0;
 
                     for (const entry of selTextMap) {
-                        if (!startNode && entry.end >= value.start) {
+                        if (!startNode && entry.end >= effectiveStart) {
                             startNode = entry.node;
-                            startOffset = value.start - entry.start;
+                            startOffset = effectiveStart - entry.start;
                         }
 
-                        if (entry.end >= value.end) {
+                        if (entry.end >= effectiveEnd) {
                             endNode = entry.node;
-                            endOffset = value.end - entry.start;
+                            endOffset = effectiveEnd - entry.start;
                             break;
                         }
                     }
@@ -1122,27 +1139,27 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                             contentForBlock = container.innerHTML;
                         } catch (e) {
                             // If we can't wrap (e.g., crosses element boundaries), fall back to text replacement
-                            const beforeText = fullText.substring(0, value.start);
-                            const selectedText = fullText.substring(value.start, value.end);
-                            const afterText = fullText.substring(value.end);
+                            const beforeText = fullText.substring(0, effectiveStart);
+                            const selectedText = fullText.substring(effectiveStart, effectiveEnd);
+                            const afterText = fullText.substring(effectiveEnd);
                             contentForBlock = escapeHTML(beforeText) +
                                 `<span class="typost-styled" data-features="${selectedFeatures.join(',')}" style="${styleString}">${escapeHTML(selectedText)}</span>` +
                                 escapeHTML(afterText);
                         }
                     } else {
                         // Fall back to simple text replacement
-                        const beforeText = fullText.substring(0, value.start);
-                        const selectedText = fullText.substring(value.start, value.end);
-                        const afterText = fullText.substring(value.end);
+                        const beforeText = fullText.substring(0, effectiveStart);
+                        const selectedText = fullText.substring(effectiveStart, effectiveEnd);
+                        const afterText = fullText.substring(effectiveEnd);
                         contentForBlock = escapeHTML(beforeText) +
                             `<span class="typost-styled" data-features="${selectedFeatures.join(',')}" style="${styleString}">${escapeHTML(selectedText)}</span>` +
                             escapeHTML(afterText);
                     }
                 } else {
                     // No existing HTML, use simple text replacement
-                    const beforeText = fullText.substring(0, value.start);
-                    const selectedText = fullText.substring(value.start, value.end);
-                    const afterText = fullText.substring(value.end);
+                    const beforeText = fullText.substring(0, effectiveStart);
+                    const selectedText = fullText.substring(effectiveStart, effectiveEnd);
+                    const afterText = fullText.substring(effectiveEnd);
                     contentForBlock = escapeHTML(beforeText) +
                         `<span class="typost-styled" data-features="${selectedFeatures.join(',')}" style="${styleString}">${escapeHTML(selectedText)}</span>` +
                         escapeHTML(afterText);
@@ -1228,7 +1245,10 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
          */
         applyFeatures() {
             const { value, onChange } = this.props;
-            const { selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight } = this.state;
+            const { selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight, savedSelectionStart, savedSelectionEnd } = this.state;
+
+            // Check if selection was lost due to modal focus and we have saved bounds
+            const selectionLost = value.start === value.end && savedSelectionStart !== null && savedSelectionEnd !== null && savedSelectionStart !== savedSelectionEnd;
 
             // Validate selection
             const validation = this.validateSelection();
@@ -1243,7 +1263,11 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
             if (selectedFeatures.length === 0 && !selectedFont && fontSize === 'inherit' && fontWeight === '400' && letterSpacing === 0 && lineHeight === 0) {
                 // Remove format if no features, font, font size, weight, letter spacing, or line height selected
-                onChange(removeFormat(value, FORMAT_TYPE));
+                if (selectionLost) {
+                    onChange(removeFormat(value, FORMAT_TYPE, savedSelectionStart, savedSelectionEnd));
+                } else {
+                    onChange(removeFormat(value, FORMAT_TYPE));
+                }
             } else {
                 // Build attributes
                 const attributes = {};
@@ -1310,10 +1334,17 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     }
                 }
 
-                onChange(applyFormat(value, {
-                    type: FORMAT_TYPE,
-                    attributes: attributes
-                }));
+                if (selectionLost) {
+                    onChange(applyFormat(value, {
+                        type: FORMAT_TYPE,
+                        attributes: attributes
+                    }, savedSelectionStart, savedSelectionEnd));
+                } else {
+                    onChange(applyFormat(value, {
+                        type: FORMAT_TYPE,
+                        attributes: attributes
+                    }));
+                }
             }
 
             this.setState({ isOpen: false, hasChanges: false });
@@ -1393,7 +1424,14 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             this.saveToHistory();
 
             const { value, onChange } = this.props;
-            onChange(removeFormat(value, FORMAT_TYPE));
+            const { savedSelectionStart, savedSelectionEnd } = this.state;
+            const selectionLost = value.start === value.end && savedSelectionStart !== null && savedSelectionEnd !== null && savedSelectionStart !== savedSelectionEnd;
+
+            if (selectionLost) {
+                onChange(removeFormat(value, FORMAT_TYPE, savedSelectionStart, savedSelectionEnd));
+            } else {
+                onChange(removeFormat(value, FORMAT_TYPE));
+            }
             this.setState({
                 selectedFeatures: [],
                 selectedFont: '',
@@ -2372,6 +2410,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             'data-fontsize-max': 'data-fontsize-max',
             'data-fontweight': 'data-fontweight',
             'data-letterspacing': 'data-letterspacing',
+            'data-lineheight': 'data-lineheight',
             'style': 'style',
             'aria-label': 'aria-label'
         },

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -971,10 +971,14 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
         /**
          * Validate selection to detect word boundary issues
          */
-        validateSelection() {
+        validateSelection(explicitStart = null, explicitEnd = null) {
             const { value } = this.props;
 
-            if (!value || value.start === value.end) {
+            // Accept explicit start/end to support saved selection bounds
+            const start = explicitStart !== null ? explicitStart : (value ? value.start : null);
+            const end = explicitEnd !== null ? explicitEnd : (value ? value.end : null);
+
+            if (!value || start === null || end === null || start === end) {
                 return { valid: true };
             }
 
@@ -988,7 +992,6 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
             // Get the full text and selection
             const fullText = getTextContent(value);
-            const { start, end } = value;
 
             // Check if selection breaks word boundaries
             const beforeChar = start > 0 ? fullText[start - 1] : ' ';
@@ -1059,7 +1062,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 const fullText = getTextContent(value);
 
                 // Build style string for the selected portion
-                const { selectedFeatures, selectedFont, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing } = this.state;
+                const { selectedFeatures, selectedFont, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight } = this.state;
                 const styleArray = [];
 
                 if (selectedFeatures.length > 0) {
@@ -1079,6 +1082,12 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     const sanitizedSpacing = parseFloat(letterSpacing) || 0;
                     styleArray.push(`letter-spacing: ${sanitizedSpacing / 1000}em`);
                 }
+                if (lineHeight && lineHeight !== 0) {
+                    const sanitizedLineHeight = parseFloat(lineHeight) || 0;
+                    if (sanitizedLineHeight > 0) {
+                        styleArray.push(`line-height: ${sanitizedLineHeight}`);
+                    }
+                }
                 if (fontSize === 'responsive') {
                     // Ensure all numeric values are actually numbers
                     const minPx = parseFloat(fontSizeMin) || 16;
@@ -1096,15 +1105,15 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     const doc = parser.parseFromString(`<div>${existingContent}</div>`, 'text/html');
                     const container = doc.body.firstChild;
 
-                    // Validate selection bounds
-                    const textLength = container.textContent.length;
+                    // Create offset map for the selection (accounts for <br> line breaks)
+                    const selTextMap = buildTextOffsetMap(container, doc);
+
+                    // Use offset map's final position for text length (matches BR counting)
+                    const textLength = selTextMap.length > 0 ? selTextMap[selTextMap.length - 1].end : container.textContent.length;
                     const validationResult = validateSelectionBounds(effectiveStart, effectiveEnd, textLength);
                     if (!validationResult.valid) {
                         return;
                     }
-
-                    // Create a range for the selection (accounts for <br> line breaks)
-                    const selTextMap = buildTextOffsetMap(container, doc);
                     let startNode = null, startOffset = 0;
                     let endNode = null, endOffset = 0;
 
@@ -1177,7 +1186,8 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                         fontSizePreferred: this.state.fontSizePreferred,
                         fontSizeMax: this.state.fontSizeMax,
                         fontWeight: this.state.fontWeight,
-                        letterSpacing: this.state.letterSpacing
+                        letterSpacing: this.state.letterSpacing,
+                        lineHeight: this.state.lineHeight
                     });
                 } else {
                     // Create new Typography Stylist block preserving user's settings from inline editor
@@ -1192,7 +1202,8 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                         fontSizePreferred: this.state.fontSizePreferred,
                         fontSizeMax: this.state.fontSizeMax,
                         fontWeight: this.state.fontWeight,
-                        letterSpacing: this.state.letterSpacing
+                        letterSpacing: this.state.letterSpacing,
+                        lineHeight: this.state.lineHeight
                     });
 
                     // Replace current block
@@ -1236,8 +1247,8 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 }
             }
 
-            // Close popover
-            this.setState({ isOpen: false });
+            // Close popover and reset open/changes flags
+            this.setState({ isOpen: false, hasChanges: false });
         }
 
         /**
@@ -1250,8 +1261,10 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             // Check if selection was lost due to modal focus and we have saved bounds
             const selectionLost = value.start === value.end && savedSelectionStart !== null && savedSelectionEnd !== null && savedSelectionStart !== savedSelectionEnd;
 
-            // Validate selection
-            const validation = this.validateSelection();
+            // Validate selection (use saved bounds if selection was lost)
+            const validation = selectionLost
+                ? this.validateSelection(savedSelectionStart, savedSelectionEnd)
+                : this.validateSelection();
             if (!validation.valid) {
                 // Show warning with options
                 this.setState({
@@ -1326,8 +1339,10 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
                 // Add aria-label if enabled for accessibility
                 if (typostData.enableAriaLabels && value) {
-                    const selectedText = value.start !== value.end
-                        ? getTextContent(slice(value, value.start, value.end))
+                    const effectiveStart = selectionLost ? savedSelectionStart : value.start;
+                    const effectiveEnd = selectionLost ? savedSelectionEnd : value.end;
+                    const selectedText = effectiveStart !== effectiveEnd
+                        ? getTextContent(slice(value, effectiveStart, effectiveEnd))
                         : getTextContent(value);
                     if (selectedText) {
                         attributes['aria-label'] = selectedText;

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -1090,9 +1090,17 @@ msgstr "No se pudo detectar la fuente para este tipo de bloque."
 msgid "For the best experience with OpenType features, consider using the Typography Stylist block instead of the inline toolbar."
 msgstr "Para obtener la mejor experiencia con las funciones OpenType, considere usar el bloque Typography Stylist en lugar de la barra de herramientas en línea."
 
-#: assets/js/block-editor.js:1572
+#: assets/js/block-editor.js:2000
 msgid "Click \"Apply\" below the preview to confirm changes."
 msgstr "Haga clic en \"Aplicar\" debajo de la vista previa para confirmar los cambios."
+
+#: assets/js/block-editor.js:2006
+msgid "Convert to a Typography Stylist block"
+msgstr "Convertir a un bloque Typography Stylist"
+
+#: assets/js/block-editor.js:2008
+msgid "to see changes in real time."
+msgstr "para ver los cambios en tiempo real."
 
 #: assets/js/block-editor.js:1825
 msgid "Do not show this warning again (this session)"

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -1090,9 +1090,17 @@ msgstr "La police n'a pas pu être détectée pour ce type de bloc."
 msgid "For the best experience with OpenType features, consider using the Typography Stylist block instead of the inline toolbar."
 msgstr "Pour une meilleure expérience avec les fonctionnalités OpenType, envisagez d'utiliser le bloc Typography Stylist au lieu de la barre d'outils en ligne."
 
-#: assets/js/block-editor.js:1572
+#: assets/js/block-editor.js:2000
 msgid "Click \"Apply\" below the preview to confirm changes."
 msgstr "Cliquez sur « Appliquer » sous l'aperçu pour confirmer les modifications."
+
+#: assets/js/block-editor.js:2006
+msgid "Convert to a Typography Stylist block"
+msgstr "Convertir en un bloc Typography Stylist"
+
+#: assets/js/block-editor.js:2008
+msgid "to see changes in real time."
+msgstr "pour voir les modifications en temps réel."
 
 #: assets/js/block-editor.js:1825
 msgid "Do not show this warning again (this session)"

--- a/languages/typography-stylist.pot
+++ b/languages/typography-stylist.pot
@@ -862,3 +862,15 @@ msgstr ""
 #: typography-stylist.php:4336
 msgid "Font cache cleared successfully. Fonts will be re-detected on the next page load."
 msgstr ""
+
+#: assets/js/block-editor.js:2000
+msgid "Click \"Apply\" below the preview to confirm changes."
+msgstr ""
+
+#: assets/js/block-editor.js:2006
+msgid "Convert to a Typography Stylist block"
+msgstr ""
+
+#: assets/js/block-editor.js:2008
+msgid "to see changes in real time."
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,9 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 = 1.2.1 =
 * Fixed: Line breaks (Shift+Enter) in Typography Stylist blocks caused words to run together in screen reader text (e.g. "MILANOCORTINA" instead of "MILANO CORTINA")
+* Fixed: Inline editor modal lost font selection state on close/reopen - selecting a font, closing the modal without applying, then reopening and clicking Apply would silently fail because stale state caused the apply logic to enter the wrong code path
+* Fixed: Missing data-lineheight attribute in format type registration - line-height values were silently dropped when reading back existing formatted content
+* Improved: Apply notice in the inline editor now includes a "Convert to a Typography Stylist block" link, guiding users toward the block type that supports real-time preview
 * Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
 * Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
 


### PR DESCRIPTION
Closes #109 

This pull request improves the reliability and user experience of the Typography Stylist plugin's inline editor, particularly around font selection persistence, formatting application, and user guidance. It addresses several bugs related to selection state and formatting, ensures all relevant attributes are handled, and enhances the user interface with clearer conversion options and updated translations.

**Bug Fixes and Reliability Improvements:**

* Fixed an issue where the inline editor modal would lose the selected font state if closed and reopened without applying, which previously caused the "Apply" action to silently fail due to stale `selectedFontId` state. Now, the selection state is properly reset and applied. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R361) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R797)
* Fixed loss of text selection when the modal loses focus: selection bounds are now saved and restored, ensuring formatting and removal actions apply to the correct text even if focus changes. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R300-R302) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R749-R755) [[3]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R812-R814) [[4]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1049-R1055) [[5]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1084-R1101) [[6]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1095-R1119) [[7]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1125-R1162) [[8]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1231-R1251) [[9]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1266-R1270) [[10]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1337-R1348) [[11]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1427-R1434)
* Fixed missing `data-lineheight` attribute in format type registration, which previously caused line-height values to be ignored when reading formatted content. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R361) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R2421) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R237-R239)

**User Experience Improvements:**

* Enhanced the apply notice in the inline editor: it now includes a "Convert to a Typography Stylist block" link, making it easier for users to switch to a block that supports real-time preview and better accessibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R361) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1962-R2008) [[3]](diffhunk://#diff-d630f0bf6b35bf3e13b7347504f1807cb29fb39f80d20e663377ec88e432a46eR55-R63) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R237-R239)
* Updated translations and translation templates to reflect the new UI text and guidance, supporting better localization in Spanish and French. [[1]](diffhunk://#diff-4bb44e9397c121e19584fb21bd6d57806a990e34eaa6b2ee8d269a26b7444e4eL1093-R1104) [[2]](diffhunk://#diff-0705093c2ed9bdf25756a26fb1f321cb356b38581b585a5b5b02e42c57aec84aL1093-R1104) [[3]](diffhunk://#diff-7eeafce655f9faf8676786b8a0d66858b392d70af47b74aa8aa2621a5dc5ef7dR865-R876)