### PR TITLE
Bugfix/#110 compound features

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 **UX Improvement:**
 - **Improved: Convert-to-block link in apply notice** - The "Click Apply below the preview to confirm changes" notice now includes a "Convert to a Typography Stylist block" link that converts the current block with features applied, guiding users toward the block type that supports real-time preview.
 
+**Preview Enhancement:**
+- **Improved: Cumulative OpenType feature previews** - Feature preview windows now show all currently-checked features combined, not just the individual feature in isolation. This accurately represents how features interact in fonts like Bookmania, where combining stylistic sets (e.g., ss10 + ss16) produces different glyphs than either set alone. Each preview always includes its own feature plus all other active features, updating in real time as features are toggled. Applies to both the inline editor popover and the Typography Stylist block's Quick Features Toggle.
+
 **Accessibility Enforcement:**
 - **Removed: "Apply Anyway" option** - The accessibility warning when selecting partial words in rich text blocks no longer offers a bypass. Users must either convert to a Typography Stylist block (which provides accessible dual-content markup) or discard their changes. This reinforces the plugin's accessibility-first approach.
 - **Changed: "Cancel" renamed to "Discard Changes"** - Clearer labeling for the action that dismisses the warning without applying styles.

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -1662,9 +1662,10 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             // Use preview text or default sample text
             const sampleText = previewText || 'ffi ffl Th AE';
 
-            // Build preview styles - with this feature only
+            // Build preview styles - with this feature AND all currently selected features
+            const allPreviewFeatures = [...new Set([feature.id, ...selectedFeatures])];
             const previewStyle = {
-                fontFeatureSettings: `"${feature.id}" 1`
+                fontFeatureSettings: allPreviewFeatures.map(f => `"${f}" 1`).join(', ')
             };
             // Use selected font, or fallback to block's inherited font when Default is selected
             const fontToUse = selectedFont || blockInheritedFont;

--- a/blocks/typography-stylist/edit.js
+++ b/blocks/typography-stylist/edit.js
@@ -2542,7 +2542,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 															className="typost-feature-preview-on typost-feature-apply-btn"
 															onClick={() => applyFeatureToSelection(feature.id)}
 															style={{
-																fontFeatureSettings: `"${feature.id}" 1`,
+																fontFeatureSettings: [...new Set([feature.id, ...features, ...inlineFeaturesAtSelection])].map(f => `"${f}" 1`).join(', '),
 																fontFamily: inlineFontFamilyAtSelection
 																	? `var(--font-${inlineFontFamilyAtSelection})`
 																	: (fontFamily || computedFont || 'inherit')

--- a/readme.txt
+++ b/readme.txt
@@ -239,6 +239,7 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Improved: Apply notice in the inline editor now includes a "Convert to a Typography Stylist block" link, guiding users toward the block type that supports real-time preview
 * Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
 * Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
+* Improved: OpenType feature previews now show cumulative checked features - toggling a stylistic set updates ALL preview windows to include that feature, accurately showing how features combine (essential for fonts like Bookmania where stylistic sets interact to produce different glyphs)
 
 = 1.2.0 =
 * Fixed: Inline styles applied to wrong character when content contains line breaks (Shift+Enter) - styling the "M" on a second line would incorrectly style the "I" instead, off by one character per line break


### PR DESCRIPTION
This pull request enhances the OpenType feature preview functionality in both the inline editor and the Typography Stylist block. The main improvement is that preview windows now display the cumulative effect of all currently selected features, rather than showing each feature in isolation. This provides a more accurate representation of how features interact, especially in complex fonts.

**Preview Enhancements:**

* All OpenType feature previews now show the combined effect of all currently checked features, updating in real time as features are toggled. This applies to both the inline editor popover and the Typography Stylist block's Quick Features Toggle, ensuring users see accurate glyph output for fonts where features interact (e.g., Bookmania). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R363-R365) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R242)

**Implementation Updates:**

* In `assets/js/block-editor.js`, the preview style for each feature now combines the current feature with all selected features using `fontFeatureSettings`.
* In `blocks/typography-stylist/edit.js`, the preview button's style similarly aggregates the feature being previewed with all other active features and inline features at the selection, ensuring consistency in previews.