### PR TITLE
feat: Add per-font weight restrictions and auto-detection for uploaded font kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,14 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ### Version 1.2.1
 
+**New Feature: Per-Font Weight Restrictions:**
+- **Added: Per-font weight configuration** - Configure which font weights are available for each font in the admin panel (Settings → Typography Stylist → Custom Fonts). All weights are enabled by default for variable font compatibility. Uncheck weights a font doesn't include to prevent users from selecting unavailable weights.
+- **Added: Single-weight auto-apply** - When a font has only one available weight, the weight selector is hidden and the weight is automatically applied.
+- **Added: Weight validation on font change** - Switching fonts automatically adjusts the weight to the closest available option if the current weight isn't supported by the new font.
+- **Changed: "Edit Fallbacks" renamed to "Edit Settings"** - Admin font management buttons now reflect the expanded functionality (fallbacks + weight configuration).
+
 **Bug Fixes:**
+- **Fixed: CSS variable trailing comma broke font loading** - Fonts without fallbacks produced invalid CSS variables (e.g. `--font-20: "EsmeraldaPro", ;` with a trailing comma), causing browsers to silently reject the `font-family` declaration on both frontend and block editor. Changed `isset()` to `!empty()` for fallback string checks.
 - **Fixed: Screen reader text missing spaces at line breaks** - When using Shift+Enter in Typography Stylist blocks, the visually-hidden screen reader text concatenated words without a space (e.g. "MILANOCORTINA" instead of "MILANO CORTINA"). Line breaks are now replaced with spaces in the accessible text output.
 - **Fixed: Inline editor modal lost font selection on close/reopen** - Selecting a font family, closing the modal without applying, then reopening and clicking Apply would silently fail. The root cause was `selectedFontId` not being reset in `togglePopover()`, leaving stale state that caused `applyFeatures()` to enter the `removeFormat` branch instead of `applyFormat`.
 - **Fixed: Missing `data-lineheight` in format type registration** - Line-height values were silently dropped when reading back existing formatted content because the attribute wasn't registered with WordPress's `registerFormatType`.

--- a/assets/css/admin-page.css
+++ b/assets/css/admin-page.css
@@ -1099,3 +1099,24 @@
 .typost-developer-support .typost-separator {
     margin: 0 10px;
 }
+
+/* Available font weight checkboxes */
+.typost-weight-checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    margin-top: 8px;
+}
+
+.typost-weight-checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 400 !important;
+    cursor: pointer;
+    min-width: 140px;
+}
+
+.typost-weight-checkbox-label input[type="checkbox"] {
+    margin: 0;
+}

--- a/assets/js/admin-page.js
+++ b/assets/js/admin-page.js
@@ -655,6 +655,10 @@ jQuery(document).ready(function($) {
         var $message = $card.find('.typost-font-edit-message');
         var fontId = $card.find('.typost-edit-font').data('font-id');
         var fallbacks = $card.find('.typost-font-fallback-input').val().trim();
+        var availableWeights = [];
+        $card.find('.typost-font-weight-checkbox:checked').each(function() {
+            availableWeights.push($(this).val());
+        });
 
         $message.html('');
         $btn.prop('disabled', true).text(typostAdmin.strings.saving);
@@ -662,7 +666,7 @@ jQuery(document).ready(function($) {
         $.ajax({
             url: typostAdmin.restUrl + 'fonts/' + fontId + '/fallback',
             method: 'PATCH',
-            data: JSON.stringify({ fallbacks: fallbacks }),
+            data: JSON.stringify({ fallbacks: fallbacks, available_weights: availableWeights }),
             contentType: 'application/json',
             beforeSend: function(xhr) {
                 xhr.setRequestHeader('X-WP-Nonce', typostAdmin.nonce);
@@ -715,6 +719,10 @@ jQuery(document).ready(function($) {
         var $message = $card.find('.typost-adobe-font-edit-message');
         var fontId = $card.find('.typost-edit-adobe-font').data('font-id');
         var fallbacks = $card.find('.typost-adobe-font-fallback-input').val().trim();
+        var availableWeights = [];
+        $card.find('.typost-adobe-weight-checkbox:checked').each(function() {
+            availableWeights.push($(this).val());
+        });
 
         $message.html('');
         $btn.prop('disabled', true).text(typostAdmin.strings.saving);
@@ -722,7 +730,7 @@ jQuery(document).ready(function($) {
         $.ajax({
             url: typostAdmin.restUrl + 'adobe-fonts/' + fontId + '/fallback',
             method: 'PATCH',
-            data: JSON.stringify({ fallbacks: fallbacks }),
+            data: JSON.stringify({ fallbacks: fallbacks, available_weights: availableWeights }),
             contentType: 'application/json',
             beforeSend: function(xhr) {
                 xhr.setRequestHeader('X-WP-Nonce', typostAdmin.nonce);
@@ -773,6 +781,10 @@ jQuery(document).ready(function($) {
         var fontId = $card.find('.typost-edit-manual-font').data('font-id');
         var fontFamily = $card.find('.typost-manual-font-family-input').val().trim();
         var fallbacks = $card.find('.typost-manual-font-fallback-input').val().trim();
+        var availableWeights = [];
+        $card.find('.typost-manual-weight-checkbox:checked').each(function() {
+            availableWeights.push($(this).val());
+        });
 
         $message.html('');
 
@@ -791,7 +803,8 @@ jQuery(document).ready(function($) {
             method: 'PATCH',
             data: JSON.stringify({
                 font_family: fontFamily,
-                fallbacks: fallbacks
+                fallbacks: fallbacks,
+                available_weights: availableWeights
             }),
             contentType: 'application/json',
             beforeSend: function(xhr) {

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -838,12 +838,26 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 const fontId = parseInt(value, 10);
                 const fontData = this.fontIdMap && this.fontIdMap[fontId];
                 if (!isNaN(fontId) && fontData) {
-                    // New ID-based system
-                    this.setState({
+                    const newState = {
                         selectedFont: fontData.family,
                         selectedFontId: fontId,
                         hasChanges: true
-                    });
+                    };
+
+                    // Validate current weight against new font's available weights
+                    const available = fontData.availableWeights;
+                    if (available && available.length > 0) {
+                        const currentWeight = this.state.fontWeight || '400';
+                        if (!available.includes(currentWeight)) {
+                            newState.fontWeight = this.getClosestWeight(currentWeight, available);
+                        }
+                        // Auto-apply single weight (if not default 400)
+                        if (available.length === 1 && this.state.fontWeight !== available[0]) {
+                            newState.fontWeight = available[0];
+                        }
+                    }
+
+                    this.setState(newState);
                 } else {
                     // Old string-based system (backward compatibility)
                     this.setState({
@@ -1513,7 +1527,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                 fontFamily: family,
                                 fontId: font.font_id
                             });
-                            this.fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks };
+                            this.fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
                         });
                     }
                 });
@@ -1530,7 +1544,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                             fontFamily: font.font_family,
                             fontId: font.font_id
                         });
-                        this.fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks };
+                        this.fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
                     }
                     // Handle legacy structure: font_families (plural array - multiple families per entry)
                     else if (font.font_families && font.font_families.length > 0 && font.font_id) {
@@ -1541,7 +1555,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                 fontFamily: family,
                                 fontId: font.font_id
                             });
-                            this.fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks };
+                            this.fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
                         });
                     }
                 });
@@ -1557,12 +1571,63 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                             fontFamily: font.font_family,
                             fontId: font.font_id
                         });
-                        this.fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks };
+                        this.fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
                     }
                 });
             }
 
             return options;
+        }
+
+        /**
+         * Get filtered weight options based on the selected font's available weights.
+         * Returns all weights if no font is selected or font has no restrictions.
+         */
+        getFilteredWeightOptions(fontId) {
+            const ALL_WEIGHTS = [
+                { label: __('100 - Thin', 'typography-stylist'), value: '100' },
+                { label: __('200 - Extra Light', 'typography-stylist'), value: '200' },
+                { label: __('300 - Light', 'typography-stylist'), value: '300' },
+                { label: __('400 - Normal', 'typography-stylist'), value: '400' },
+                { label: __('500 - Medium', 'typography-stylist'), value: '500' },
+                { label: __('600 - Semi Bold', 'typography-stylist'), value: '600' },
+                { label: __('700 - Bold', 'typography-stylist'), value: '700' },
+                { label: __('800 - Extra Bold', 'typography-stylist'), value: '800' },
+                { label: __('900 - Black', 'typography-stylist'), value: '900' }
+            ];
+
+            if (!fontId || !this.fontIdMap || !this.fontIdMap[fontId]) {
+                return ALL_WEIGHTS;
+            }
+
+            const available = this.fontIdMap[fontId].availableWeights;
+            if (!available || available.length === 0) {
+                return ALL_WEIGHTS;
+            }
+
+            return ALL_WEIGHTS.filter(w => available.includes(w.value));
+        }
+
+        /**
+         * Get the closest available weight to the given weight.
+         * Used when switching fonts and the current weight isn't available.
+         */
+        getClosestWeight(currentWeight, availableWeights) {
+            if (!availableWeights || availableWeights.length === 0) return currentWeight;
+            if (availableWeights.includes(currentWeight)) return currentWeight;
+
+            const current = parseInt(currentWeight, 10);
+            let closest = availableWeights[0];
+            let minDiff = Math.abs(current - parseInt(closest, 10));
+
+            for (const w of availableWeights) {
+                const diff = Math.abs(current - parseInt(w, 10));
+                if (diff < minDiff) {
+                    minDiff = diff;
+                    closest = w;
+                }
+            }
+            return closest;
         }
 
         /**
@@ -2060,25 +2125,21 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                     </div>
                                 )}
 
-                                {/* Font Weight Control */}
-                                <div className="typost-fontweight-section">
-                                    <h4>{__('Font Weight', 'typography-stylist')}</h4>
-                                    <SelectControl
-                                        value={fontWeight}
-                                        options={[
-                                            { label: __('100 - Thin', 'typography-stylist'), value: '100' },
-                                            { label: __('200 - Extra Light', 'typography-stylist'), value: '200' },
-                                            { label: __('300 - Light', 'typography-stylist'), value: '300' },
-                                            { label: __('400 - Normal', 'typography-stylist'), value: '400' },
-                                            { label: __('500 - Medium', 'typography-stylist'), value: '500' },
-                                            { label: __('600 - Semi Bold', 'typography-stylist'), value: '600' },
-                                            { label: __('700 - Bold', 'typography-stylist'), value: '700' },
-                                            { label: __('800 - Extra Bold', 'typography-stylist'), value: '800' },
-                                            { label: __('900 - Black', 'typography-stylist'), value: '900' }
-                                        ]}
-                                        onChange={this.setFontWeight}
-                                    />
-                                </div>
+                                {/* Font Weight Control - hidden when font has only one available weight */}
+                                {(() => {
+                                    const weightOptions = this.getFilteredWeightOptions(this.state.selectedFontId);
+                                    if (weightOptions.length <= 1) return null;
+                                    return (
+                                        <div className="typost-fontweight-section">
+                                            <h4>{__('Font Weight', 'typography-stylist')}</h4>
+                                            <SelectControl
+                                                value={fontWeight}
+                                                options={weightOptions}
+                                                onChange={this.setFontWeight}
+                                            />
+                                        </div>
+                                    );
+                                })()}
 
                                 {/* Font Size Controls */}
                                 <div className="typost-fontsize-section">

--- a/blocks/typography-stylist/__tests__/weight-filtering.test.js
+++ b/blocks/typography-stylist/__tests__/weight-filtering.test.js
@@ -1,0 +1,150 @@
+/**
+ * Test Suite: Font Weight Filtering Utilities
+ *
+ * Tests for getFilteredWeightOptions, getClosestWeight, and ALL_WEIGHT_OPTIONS
+ * used for per-font weight restriction feature.
+ */
+
+import { getFilteredWeightOptions, getClosestWeight, ALL_WEIGHT_OPTIONS } from '../utils';
+
+describe('Typography Stylist - ALL_WEIGHT_OPTIONS', () => {
+
+	test('contains all 9 standard CSS font weights', () => {
+		expect(ALL_WEIGHT_OPTIONS).toHaveLength(9);
+		const values = ALL_WEIGHT_OPTIONS.map(w => w.value);
+		expect(values).toEqual(['100', '200', '300', '400', '500', '600', '700', '800', '900']);
+	});
+
+	test('each option has label and value', () => {
+		ALL_WEIGHT_OPTIONS.forEach(option => {
+			expect(option).toHaveProperty('label');
+			expect(option).toHaveProperty('value');
+			expect(typeof option.label).toBe('string');
+			expect(typeof option.value).toBe('string');
+		});
+	});
+});
+
+describe('Typography Stylist - getFilteredWeightOptions()', () => {
+
+	const fontIdMap = {
+		1: { family: 'Bookmania', fallbacks: 'serif', availableWeights: ['400', '700'] },
+		2: { family: 'Open Sans', fallbacks: 'sans-serif', availableWeights: [] }, // All weights (variable)
+		3: { family: 'Thin Only', fallbacks: 'serif', availableWeights: ['100'] },
+		4: { family: 'No Weights Field', fallbacks: 'serif' }, // No availableWeights key at all
+	};
+
+	test('returns all 9 weights when no font selected (fontId = 0)', () => {
+		const result = getFilteredWeightOptions(0, fontIdMap);
+		expect(result).toHaveLength(9);
+	});
+
+	test('returns all 9 weights when no font selected (fontId = null)', () => {
+		const result = getFilteredWeightOptions(null, fontIdMap);
+		expect(result).toHaveLength(9);
+	});
+
+	test('returns all 9 weights when fontIdMap is null', () => {
+		const result = getFilteredWeightOptions(1, null);
+		expect(result).toHaveLength(9);
+	});
+
+	test('returns all 9 weights when font has empty availableWeights (variable font)', () => {
+		const result = getFilteredWeightOptions(2, fontIdMap);
+		expect(result).toHaveLength(9);
+	});
+
+	test('returns all 9 weights when font has no availableWeights property', () => {
+		const result = getFilteredWeightOptions(4, fontIdMap);
+		expect(result).toHaveLength(9);
+	});
+
+	test('returns all 9 weights when fontId not in map', () => {
+		const result = getFilteredWeightOptions(999, fontIdMap);
+		expect(result).toHaveLength(9);
+	});
+
+	test('filters to only available weights for restricted font', () => {
+		const result = getFilteredWeightOptions(1, fontIdMap);
+		expect(result).toHaveLength(2);
+		expect(result.map(w => w.value)).toEqual(['400', '700']);
+	});
+
+	test('returns single weight for font with only one weight', () => {
+		const result = getFilteredWeightOptions(3, fontIdMap);
+		expect(result).toHaveLength(1);
+		expect(result[0].value).toBe('100');
+	});
+
+	test('includes Inherit option when includeInherit is true', () => {
+		const result = getFilteredWeightOptions(1, fontIdMap, true);
+		expect(result).toHaveLength(3); // inherit + 400 + 700
+		expect(result[0].value).toBe('inherit');
+		expect(result[0].label).toBe('Inherit from block');
+	});
+
+	test('includes Inherit + all 9 weights when font not selected and includeInherit is true', () => {
+		const result = getFilteredWeightOptions(null, fontIdMap, true);
+		expect(result).toHaveLength(10); // inherit + 9 weights
+		expect(result[0].value).toBe('inherit');
+	});
+
+	test('preserves label text from ALL_WEIGHT_OPTIONS', () => {
+		const result = getFilteredWeightOptions(1, fontIdMap);
+		const normalOption = result.find(w => w.value === '400');
+		expect(normalOption.label).toContain('Normal');
+		const boldOption = result.find(w => w.value === '700');
+		expect(boldOption.label).toContain('Bold');
+	});
+});
+
+describe('Typography Stylist - getClosestWeight()', () => {
+
+	test('returns current weight if it is available', () => {
+		expect(getClosestWeight('400', ['400', '700'])).toBe('400');
+	});
+
+	test('returns current weight if availableWeights is empty', () => {
+		expect(getClosestWeight('400', [])).toBe('400');
+	});
+
+	test('returns current weight if availableWeights is null', () => {
+		expect(getClosestWeight('400', null)).toBe('400');
+	});
+
+	test('returns current weight if availableWeights is undefined', () => {
+		expect(getClosestWeight('400', undefined)).toBe('400');
+	});
+
+	test('returns closest weight (lower) when current is unavailable', () => {
+		// Current: 300, available: 200, 700 → closest is 200 (diff 100 vs 400)
+		expect(getClosestWeight('300', ['200', '700'])).toBe('200');
+	});
+
+	test('returns closest weight (higher) when current is unavailable', () => {
+		// Current: 600, available: 200, 700 → closest is 700 (diff 100 vs 400)
+		expect(getClosestWeight('600', ['200', '700'])).toBe('700');
+	});
+
+	test('returns closest weight when equidistant (picks first found)', () => {
+		// Current: 500, available: 300, 700 → both diff 200, picks first (300)
+		expect(getClosestWeight('500', ['300', '700'])).toBe('300');
+	});
+
+	test('works with single available weight', () => {
+		expect(getClosestWeight('400', ['100'])).toBe('100');
+	});
+
+	test('works when current weight is at extreme low', () => {
+		expect(getClosestWeight('100', ['400', '700', '900'])).toBe('400');
+	});
+
+	test('works when current weight is at extreme high', () => {
+		expect(getClosestWeight('900', ['100', '200', '300'])).toBe('300');
+	});
+
+	test('handles all weights available (returns exact match)', () => {
+		const allWeights = ['100', '200', '300', '400', '500', '600', '700', '800', '900'];
+		expect(getClosestWeight('500', allWeights)).toBe('500');
+	});
+});

--- a/blocks/typography-stylist/edit.js
+++ b/blocks/typography-stylist/edit.js
@@ -29,7 +29,7 @@ import {
 import { useState, useRef, useEffect, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { create, slice as sliceRichText, getTextContent } from '@wordpress/rich-text';
-import { buildTextOffsetMap, parseInlineStylesAtCursor, updateSpanPropertyInPlace, splitSpanAndApply, detectBlockComputedFont, applyOrMergeStyling, validateRangeMatchesSelection, applyStylingSafeStringMethod, isValidFontSizeRange, debounce, removePropertyFromSelection } from './utils';
+import { buildTextOffsetMap, parseInlineStylesAtCursor, updateSpanPropertyInPlace, splitSpanAndApply, detectBlockComputedFont, applyOrMergeStyling, validateRangeMatchesSelection, applyStylingSafeStringMethod, isValidFontSizeRange, debounce, removePropertyFromSelection, getFilteredWeightOptions as getFilteredWeightOptionsUtil, getClosestWeight as getClosestWeightUtil, ALL_WEIGHT_OPTIONS } from './utils';
 import { calculateResize } from '../../assets/js/modal-drag-resize';
 
 // Viewport breakpoints for responsive font sizing
@@ -1008,7 +1008,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 					fontFamily: family,
 					fontId: font.font_id
 				});
-				fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks };
+				fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
 			});
 		}
 	});
@@ -1023,7 +1023,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 				fontFamily: font.font_family,
 				fontId: font.font_id
 			});
-			fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks };
+			fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
 		}
 		// Handle legacy structure: font_families (plural array - multiple families per entry)
 		else if (font.font_families && font.font_families.length > 0 && font.font_id) {
@@ -1034,7 +1034,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 					fontFamily: family,
 					fontId: font.font_id
 				});
-				fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks };
+				fontIdMap[font.font_id] = { family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
 			});
 		}
 	});
@@ -1048,9 +1048,16 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 				fontFamily: font.font_family,
 				fontId: font.font_id
 			});
-			fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks };
+			fontIdMap[font.font_id] = { family: font.font_family, fallbacks: font.fallbacks, availableWeights: font.available_weights || [] };
 		}
 	});
+
+	// Wrappers around utils.js helpers, binding to local fontIdMap
+	const getFilteredWeightOptions = (targetFontId, includeInherit = false) =>
+		getFilteredWeightOptionsUtil(targetFontId, fontIdMap, includeInherit);
+
+	const getClosestWeight = (currentWeight, availableWeights) =>
+		getClosestWeightUtil(currentWeight, availableWeights);
 
 	const toggleFeature = (featureId) => {
 		// Check if we have a valid selection - if so, toggle inline instead
@@ -2276,6 +2283,20 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 											setInlineFontFamily(value);
 											if (value) {
 												debouncedApplyFontFamily();
+												// Validate inline weight against new font
+												const newFontId = parseInt(value, 10);
+												if (!isNaN(newFontId) && fontIdMap[newFontId]) {
+													const available = fontIdMap[newFontId].availableWeights;
+													if (available && available.length > 0 && inlineFontWeight !== 'inherit') {
+														if (!available.includes(inlineFontWeight)) {
+															setInlineFontWeight(getClosestWeight(inlineFontWeight, available));
+														}
+														if (available.length === 1) {
+															setInlineFontWeight(available[0]);
+															debouncedApplyFontWeight();
+														}
+													}
+												}
 											}
 										}}
 										options={[
@@ -2296,42 +2317,40 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 									)}
 								</div>
 
-								{/* Font Weight Control */}
-								<div style={{ marginBottom: '16px', paddingBottom: '16px', borderBottom: '2px solid #ddd' }}>
-									<SelectControl
-										label={__('Font Weight (for selected text)', 'typography-stylist')}
-										value={inlineFontWeight}
-										onChange={(value) => {
-											setInlineFontWeight(value);
-											if (value !== 'inherit') {
-												debouncedApplyFontWeight();
-											}
-										}}
-										options={[
-											{ label: __('Inherit from block', 'typography-stylist'), value: 'inherit' },
-											{ label: '100 - Thin', value: '100' },
-											{ label: '200 - Extra Light', value: '200' },
-											{ label: '300 - Light', value: '300' },
-											{ label: '400 - Normal', value: '400' },
-											{ label: '500 - Medium', value: '500' },
-											{ label: '600 - Semi Bold', value: '600' },
-											{ label: '700 - Bold', value: '700' },
-											{ label: '800 - Extra Bold', value: '800' },
-											{ label: '900 - Black', value: '900' }
-										]}
-									/>
-									{inlineFontWeight !== 'inherit' && (
-										<Button
-											variant="secondary"
-											onClick={resetFontWeight}
-											isDestructive
-											style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
-											icon="undo"
-										>
-											{__('Reset Font Weight', 'typography-stylist')}
-										</Button>
-									)}
-								</div>
+								{/* Font Weight Control - use inline font if present, else block font */}
+								{(() => {
+									const activeFontId = inlineFontFamilyAtSelection || fontId;
+									const inlineWeightOptions = getFilteredWeightOptions(activeFontId, true);
+									// Hide if only "Inherit" + 1 weight (or fewer) — means the font has a single weight
+									const weightOnlyOptions = inlineWeightOptions.filter(o => o.value !== 'inherit');
+									if (weightOnlyOptions.length <= 1) return null;
+									return (
+										<div style={{ marginBottom: '16px', paddingBottom: '16px', borderBottom: '2px solid #ddd' }}>
+											<SelectControl
+												label={__('Font Weight (for selected text)', 'typography-stylist')}
+												value={inlineFontWeight}
+												onChange={(value) => {
+													setInlineFontWeight(value);
+													if (value !== 'inherit') {
+														debouncedApplyFontWeight();
+													}
+												}}
+												options={inlineWeightOptions}
+											/>
+											{inlineFontWeight !== 'inherit' && (
+												<Button
+													variant="secondary"
+													onClick={resetFontWeight}
+													isDestructive
+													style={{ marginTop: '8px', fontSize: '11px', padding: '2px 8px', height: 'auto' }}
+													icon="undo"
+												>
+													{__('Reset Font Weight', 'typography-stylist')}
+												</Button>
+											)}
+										</div>
+									);
+								})()}
 
 								{/* Font Size Control */}
 								<div style={{ marginBottom: '16px', paddingBottom: '16px', borderBottom: '2px solid #ddd' }}>
@@ -2646,10 +2665,23 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 									if (!isNaN(selectedFontId) && fontIdMap[selectedFontId]) {
 										// New ID-based system
 										const fontData = fontIdMap[selectedFontId];
-										setAttributes({
+										const newAttrs = {
 											fontFamily: fontData.family,
 											fontId: selectedFontId
-										});
+										};
+
+										// Validate weight against new font's available weights
+										const available = fontData.availableWeights;
+										if (available && available.length > 0) {
+											if (!available.includes(fontWeight)) {
+												newAttrs.fontWeight = getClosestWeight(fontWeight, available);
+											}
+											if (available.length === 1 && fontWeight !== available[0]) {
+												newAttrs.fontWeight = available[0];
+											}
+										}
+
+										setAttributes(newAttrs);
 									} else {
 										// Old string-based system (backward compatibility)
 										setAttributes({
@@ -2663,23 +2695,20 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 					</PanelBody>
 				)}
 
-				<PanelBody title={__('Font Weight', 'typography-stylist')} initialOpen={false}>
-					<SelectControl
-						value={fontWeight}
-						options={[
-							{ label: __('100 - Thin', 'typography-stylist'), value: '100' },
-							{ label: __('200 - Extra Light', 'typography-stylist'), value: '200' },
-							{ label: __('300 - Light', 'typography-stylist'), value: '300' },
-							{ label: __('400 - Normal', 'typography-stylist'), value: '400' },
-							{ label: __('500 - Medium', 'typography-stylist'), value: '500' },
-							{ label: __('600 - Semi Bold', 'typography-stylist'), value: '600' },
-							{ label: __('700 - Bold', 'typography-stylist'), value: '700' },
-							{ label: __('800 - Extra Bold', 'typography-stylist'), value: '800' },
-							{ label: __('900 - Black', 'typography-stylist'), value: '900' }
-						]}
-						onChange={(value) => setAttributes({ fontWeight: value })}
-					/>
-				</PanelBody>
+				{/* Font Weight - hidden when font has only one available weight */}
+				{(() => {
+					const sidebarWeightOptions = getFilteredWeightOptions(fontId, false);
+					if (sidebarWeightOptions.length <= 1) return null;
+					return (
+						<PanelBody title={__('Font Weight', 'typography-stylist')} initialOpen={false}>
+							<SelectControl
+								value={fontWeight}
+								options={sidebarWeightOptions}
+								onChange={(value) => setAttributes({ fontWeight: value })}
+							/>
+						</PanelBody>
+					);
+				})()}
 
 				<PanelBody title={__('Font Size', 'typography-stylist')} initialOpen={false}>
 					<SelectControl

--- a/blocks/typography-stylist/utils.js
+++ b/blocks/typography-stylist/utils.js
@@ -1688,6 +1688,71 @@ export function removePropertyFromSelection(htmlContent, startOffset, endOffset,
 	};
 }
 
+/**
+ * Standard CSS font weight options.
+ */
+export const ALL_WEIGHT_OPTIONS = [
+	{ label: '100 - Thin', value: '100' },
+	{ label: '200 - Extra Light', value: '200' },
+	{ label: '300 - Light', value: '300' },
+	{ label: '400 - Normal', value: '400' },
+	{ label: '500 - Medium', value: '500' },
+	{ label: '600 - Semi Bold', value: '600' },
+	{ label: '700 - Bold', value: '700' },
+	{ label: '800 - Extra Bold', value: '800' },
+	{ label: '900 - Black', value: '900' }
+];
+
+/**
+ * Get filtered font weight options based on a font's available weights.
+ *
+ * @param {number|string} targetFontId   The font ID to check weights for.
+ * @param {Object}        fontIdMap      Map of font ID to font data (must include availableWeights).
+ * @param {boolean}       includeInherit Whether to include an "Inherit from block" option.
+ * @return {Array} Filtered weight options array with { label, value } objects.
+ */
+export function getFilteredWeightOptions(targetFontId, fontIdMap, includeInherit = false) {
+	const options = includeInherit
+		? [{ label: 'Inherit from block', value: 'inherit' }]
+		: [];
+
+	if (!targetFontId || !fontIdMap || !fontIdMap[targetFontId]) {
+		return options.concat(ALL_WEIGHT_OPTIONS);
+	}
+
+	const available = fontIdMap[targetFontId].availableWeights;
+	if (!available || available.length === 0) {
+		return options.concat(ALL_WEIGHT_OPTIONS);
+	}
+
+	return options.concat(ALL_WEIGHT_OPTIONS.filter(w => available.includes(w.value)));
+}
+
+/**
+ * Get the closest available weight to the given weight.
+ *
+ * @param {string} currentWeight    The current weight value (e.g., '400').
+ * @param {Array}  availableWeights Array of available weight strings (e.g., ['200', '700']).
+ * @return {string} The closest available weight.
+ */
+export function getClosestWeight(currentWeight, availableWeights) {
+	if (!availableWeights || availableWeights.length === 0) return currentWeight;
+	if (availableWeights.includes(currentWeight)) return currentWeight;
+
+	const current = parseInt(currentWeight, 10);
+	let closest = availableWeights[0];
+	let minDiff = Math.abs(current - parseInt(closest, 10));
+
+	for (const w of availableWeights) {
+		const diff = Math.abs(current - parseInt(w, 10));
+		if (diff < minDiff) {
+			minDiff = diff;
+			closest = w;
+		}
+	}
+	return closest;
+}
+
 // Expose utility functions for cross-module use (block-editor.js uses CommonJS/Browserify)
 if (typeof window !== 'undefined') {
 	window.typostSharedUtils = {

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -20,6 +20,53 @@ if (!defined('ABSPATH')) {
  * @param array              $adobe_fonts   Array of Adobe Fonts configurations
  * @param array              $manual_fonts  Array of manually defined fonts
  */
+/**
+ * Render available font weight checkboxes for the admin edit form
+ *
+ * @param array  $font       Font data array containing 'id' and optionally 'available_weights'.
+ * @param string $prefix     CSS class/ID prefix for the font type (e.g., 'font', 'adobe', 'manual').
+ * @param bool   $show_auto  Whether to show "Auto-detected from font files" note.
+ */
+function typost_render_weight_checkboxes($font, $prefix, $show_auto = false) {
+    $weights = array(
+        '100' => __('100 - Thin', 'typography-stylist'),
+        '200' => __('200 - Extra Light', 'typography-stylist'),
+        '300' => __('300 - Light', 'typography-stylist'),
+        '400' => __('400 - Normal', 'typography-stylist'),
+        '500' => __('500 - Medium', 'typography-stylist'),
+        '600' => __('600 - Semi Bold', 'typography-stylist'),
+        '700' => __('700 - Bold', 'typography-stylist'),
+        '800' => __('800 - Extra Bold', 'typography-stylist'),
+        '900' => __('900 - Black', 'typography-stylist'),
+    );
+    $available = !empty($font['available_weights']) ? $font['available_weights'] : array();
+    $all_available = empty($available); // Empty array = all weights available
+    ?>
+    <div class="typost-form-field">
+        <label><?php esc_html_e('Available Font Weights:', 'typography-stylist'); ?></label>
+        <p class="description" id="typost-<?php echo esc_attr($prefix); ?>-weights-desc-<?php echo esc_attr($font['id']); ?>">
+            <?php esc_html_e('Uncheck weights this font doesn\'t include to exclude them from being selected. You can leave all checked for variable fonts.', 'typography-stylist'); ?>
+            <?php if ($show_auto && !empty($font['available_weights'])): ?>
+                <br><em><?php esc_html_e('Auto-detected from font files.', 'typography-stylist'); ?></em>
+            <?php endif; ?>
+        </p>
+        <div class="typost-weight-checkboxes"
+            aria-describedby="typost-<?php echo esc_attr($prefix); ?>-weights-desc-<?php echo esc_attr($font['id']); ?>">
+            <?php foreach ($weights as $value => $label): ?>
+                <label class="typost-weight-checkbox-label">
+                    <input
+                        type="checkbox"
+                        class="typost-<?php echo esc_attr($prefix); ?>-weight-checkbox"
+                        value="<?php echo esc_attr($value); ?>"
+                        <?php checked($all_available || in_array((string) $value, $available, true)); ?> />
+                    <?php echo esc_html($label); ?>
+                </label>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php
+}
+
 function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe_fonts, $manual_fonts) {
     ?>
 <div class="wrap typost-admin-wrap">
@@ -380,9 +427,9 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                         data-font-id="<?php echo esc_attr($font['id']); ?>"
                                         data-font-name="<?php echo esc_attr($font['name']); ?>"
                                         <?php /* translators: %s: The name of the font to be edited */ ?>
-                                        aria-label="<?php echo esc_attr(sprintf(__('Edit fallback fonts for: %s', 'typography-stylist'), $font['name'])); ?>">
+                                        aria-label="<?php echo esc_attr(sprintf(__('Edit settings for: %s', 'typography-stylist'), $font['name'])); ?>">
                                         <span aria-hidden="true" class="dashicons dashicons-edit"></span>
-                                        <?php esc_html_e('Edit Fallbacks', 'typography-stylist'); ?>
+                                        <?php esc_html_e('Edit Settings', 'typography-stylist'); ?>
                                     </button>
                                     <button
                                         class="button typost-delete-font"
@@ -457,6 +504,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                         <?php esc_html_e('Enter fallback fonts separated by commas (these will be used if the primary font fails to load)', 'typography-stylist'); ?>
                                     </p>
                                 </div>
+                                <?php typost_render_weight_checkboxes($font, 'font', true); ?>
                                 <div class="typost-form-actions">
                                     <button type="button" class="button button-primary typost-save-font-edit">
                                         <?php esc_html_e('Save Changes', 'typography-stylist'); ?>
@@ -484,9 +532,9 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                 data-font-id="<?php echo esc_attr($font['id']); ?>"
                                 data-font-name="<?php echo esc_attr($font['name']); ?>"
                                 <?php /* translators: %s: The name of the font kit to be edited */ ?>
-                                aria-label="<?php echo esc_attr(sprintf(__('Edit fallback fonts for: %s', 'typography-stylist'), $font['name'])); ?>">
+                                aria-label="<?php echo esc_attr(sprintf(__('Edit settings for: %s', 'typography-stylist'), $font['name'])); ?>">
                                 <span aria-hidden="true" class="dashicons dashicons-edit"></span>
-                                <?php esc_html_e('Edit Fallbacks', 'typography-stylist'); ?>
+                                <?php esc_html_e('Edit Settings', 'typography-stylist'); ?>
                             </button>
                             <button
                                 class="button typost-delete-font"
@@ -578,6 +626,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                 <?php esc_html_e('Enter fallback fonts separated by commas (these will be used if the primary font fails to load)', 'typography-stylist'); ?>
                             </p>
                         </div>
+                        <?php typost_render_weight_checkboxes($font, 'font', true); ?>
                         <div class="typost-form-actions">
                             <button type="button" class="button button-primary typost-save-font-edit">
                                 <?php esc_html_e('Save Changes', 'typography-stylist'); ?>
@@ -776,9 +825,9 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                             data-font-id="<?php echo esc_attr($font['id']); ?>"
                                             data-font-name="<?php echo esc_attr($font['name']); ?>"
                                             <?php /* translators: %s: The name of the Adobe font to be edited */ ?>
-                                            aria-label="<?php echo esc_attr(sprintf(__('Edit fallback fonts for: %s', 'typography-stylist'), $font['name'])); ?>">
+                                            aria-label="<?php echo esc_attr(sprintf(__('Edit settings for: %s', 'typography-stylist'), $font['name'])); ?>">
                                             <span aria-hidden="true" class="dashicons dashicons-edit"></span>
-                                            <?php esc_html_e('Edit Fallbacks', 'typography-stylist'); ?>
+                                            <?php esc_html_e('Edit Settings', 'typography-stylist'); ?>
                                         </button>
                                         <button
                                             class="button typost-delete-adobe-font"
@@ -839,6 +888,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                             <?php esc_html_e('Enter fallback fonts separated by commas (these will be used if the primary font fails to load)', 'typography-stylist'); ?>
                                         </p>
                                     </div>
+                                    <?php typost_render_weight_checkboxes($font, 'adobe', false); ?>
                                     <div class="typost-form-actions">
                                         <button type="button" class="button button-primary typost-save-adobe-font-edit">
                                             <?php esc_html_e('Save Changes', 'typography-stylist'); ?>
@@ -866,9 +916,9 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                     data-font-id="<?php echo esc_attr($font['id']); ?>"
                                     data-font-name="<?php echo esc_attr($font['name']); ?>"
                                     <?php /* translators: %s: The name of the Adobe font project to be edited */ ?>
-                                    aria-label="<?php echo esc_attr(sprintf(__('Edit fallback fonts for: %s', 'typography-stylist'), $font['name'])); ?>">
+                                    aria-label="<?php echo esc_attr(sprintf(__('Edit settings for: %s', 'typography-stylist'), $font['name'])); ?>">
                                     <span aria-hidden="true" class="dashicons dashicons-edit"></span>
-                                    <?php esc_html_e('Edit Fallbacks', 'typography-stylist'); ?>
+                                    <?php esc_html_e('Edit Settings', 'typography-stylist'); ?>
                                 </button>
                                 <button
                                     class="button typost-delete-adobe-font"
@@ -950,6 +1000,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                     <?php esc_html_e('Enter fallback fonts separated by commas (these will be used if the primary font fails to load)', 'typography-stylist'); ?>
                                 </p>
                             </div>
+                            <?php typost_render_weight_checkboxes($font, 'adobe', false); ?>
                             <div class="typost-form-actions">
                                 <button type="button" class="button button-primary typost-save-adobe-font-edit">
                                     <?php esc_html_e('Save Changes', 'typography-stylist'); ?>
@@ -1113,6 +1164,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                     <?php esc_html_e('Enter the exact CSS font-family value including any fallback fonts (e.g., \'Playfair Display\', Georgia, serif)', 'typography-stylist'); ?>
                                 </p>
                             </div>
+                            <?php typost_render_weight_checkboxes($font, 'manual', false); ?>
                             <div class="typost-form-actions">
                                 <button type="button" class="button button-primary typost-save-manual-font-edit">
                                     <?php esc_html_e('Save Changes', 'typography-stylist'); ?>

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -1284,3 +1284,12 @@ msgstr "Detectado automáticamente de los archivos de fuente."
 #, php-format
 msgid "Edit settings for: %s"
 msgstr "Editar configuración para: %s"
+
+#: typography-stylist.php:3125
+#: typography-stylist.php:3208
+msgid "Either fallbacks or available_weights parameter is required"
+msgstr "Se requiere el parámetro fallbacks o available_weights"
+
+#: typography-stylist.php:3378
+msgid "Either font_family or available_weights parameter is required"
+msgstr "Se requiere el parámetro font_family o available_weights"

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -1263,3 +1263,24 @@ msgstr "Borrar caché de fuentes"
 #: typography-stylist.php:4336
 msgid "Font cache cleared successfully. Fonts will be re-detected on the next page load."
 msgstr "Caché de fuentes borrado correctamente. Las fuentes se volverán a detectar en la próxima carga de página."
+
+#: includes/admin-page.php
+msgid "Edit Settings"
+msgstr "Editar configuración"
+
+#: includes/admin-page.php
+msgid "Available Font Weights:"
+msgstr "Pesos de fuente disponibles:"
+
+#: includes/admin-page.php
+msgid "Uncheck weights this font doesn't include to exclude them from being selected. You can leave all checked for variable fonts."
+msgstr "Desmarca los pesos que esta fuente no incluye para excluirlos de la selección. Puedes dejar todos marcados para fuentes variables."
+
+#: includes/admin-page.php
+msgid "Auto-detected from font files."
+msgstr "Detectado automáticamente de los archivos de fuente."
+
+#: includes/admin-page.php
+#, php-format
+msgid "Edit settings for: %s"
+msgstr "Editar configuración para: %s"

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -1284,3 +1284,12 @@ msgstr "Détecté automatiquement à partir des fichiers de police."
 #, php-format
 msgid "Edit settings for: %s"
 msgstr "Modifier les paramètres pour : %s"
+
+#: typography-stylist.php:3125
+#: typography-stylist.php:3208
+msgid "Either fallbacks or available_weights parameter is required"
+msgstr "Le paramètre fallbacks ou available_weights est requis"
+
+#: typography-stylist.php:3378
+msgid "Either font_family or available_weights parameter is required"
+msgstr "Le paramètre font_family ou available_weights est requis"

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -1263,3 +1263,24 @@ msgstr "Vider le cache des polices"
 #: typography-stylist.php:4336
 msgid "Font cache cleared successfully. Fonts will be re-detected on the next page load."
 msgstr "Cache des polices vidé avec succès. Les polices seront à nouveau détectées lors du prochain chargement de page."
+
+#: includes/admin-page.php
+msgid "Edit Settings"
+msgstr "Modifier les paramètres"
+
+#: includes/admin-page.php
+msgid "Available Font Weights:"
+msgstr "Graisses de police disponibles :"
+
+#: includes/admin-page.php
+msgid "Uncheck weights this font doesn't include to exclude them from being selected. You can leave all checked for variable fonts."
+msgstr "Décochez les graisses que cette police n'inclut pas pour les exclure de la sélection. Vous pouvez laisser tout coché pour les polices variables."
+
+#: includes/admin-page.php
+msgid "Auto-detected from font files."
+msgstr "Détecté automatiquement à partir des fichiers de police."
+
+#: includes/admin-page.php
+#, php-format
+msgid "Edit settings for: %s"
+msgstr "Modifier les paramètres pour : %s"

--- a/languages/typography-stylist.pot
+++ b/languages/typography-stylist.pot
@@ -874,3 +874,24 @@ msgstr ""
 #: assets/js/block-editor.js:2008
 msgid "to see changes in real time."
 msgstr ""
+
+#: includes/admin-page.php
+msgid "Edit Settings"
+msgstr ""
+
+#: includes/admin-page.php
+msgid "Available Font Weights:"
+msgstr ""
+
+#: includes/admin-page.php
+msgid "Uncheck weights this font doesn't include to exclude them from being selected. You can leave all checked for variable fonts."
+msgstr ""
+
+#: includes/admin-page.php
+msgid "Auto-detected from font files."
+msgstr ""
+
+#: includes/admin-page.php
+#, php-format
+msgid "Edit settings for: %s"
+msgstr ""

--- a/languages/typography-stylist.pot
+++ b/languages/typography-stylist.pot
@@ -895,3 +895,12 @@ msgstr ""
 #, php-format
 msgid "Edit settings for: %s"
 msgstr ""
+
+#: typography-stylist.php:3125
+#: typography-stylist.php:3208
+msgid "Either fallbacks or available_weights parameter is required"
+msgstr ""
+
+#: typography-stylist.php:3378
+msgid "Either font_family or available_weights parameter is required"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -234,7 +234,6 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 = 1.2.1 =
 * Added: Per-font weight restrictions - configure which font weights are available for each font in the admin panel (Settings → Typography Stylist → Custom Fonts). Fonts default to all weights for variable font compatibility
-* Added: Weight auto-detection for uploaded font kits - available weights are automatically detected from font files during upload
 * Added: Single-weight auto-apply - when a font has only one available weight, the weight selector is hidden and the weight is automatically applied
 * Added: Weight validation on font change - switching fonts automatically adjusts the weight to the closest available option
 * Fixed: CSS variable trailing comma caused fonts without fallbacks to fail loading on both frontend and block editor (e.g. `--font-20: "EsmeraldaPro", ;` produced invalid CSS)

--- a/readme.txt
+++ b/readme.txt
@@ -233,12 +233,18 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 == Changelog ==
 
 = 1.2.1 =
+* Added: Per-font weight restrictions - configure which font weights are available for each font in the admin panel (Settings → Typography Stylist → Custom Fonts). Fonts default to all weights for variable font compatibility
+* Added: Weight auto-detection for uploaded font kits - available weights are automatically detected from font files during upload
+* Added: Single-weight auto-apply - when a font has only one available weight, the weight selector is hidden and the weight is automatically applied
+* Added: Weight validation on font change - switching fonts automatically adjusts the weight to the closest available option
+* Fixed: CSS variable trailing comma caused fonts without fallbacks to fail loading on both frontend and block editor (e.g. `--font-20: "EsmeraldaPro", ;` produced invalid CSS)
 * Fixed: Line breaks (Shift+Enter) in Typography Stylist blocks caused words to run together in screen reader text (e.g. "MILANOCORTINA" instead of "MILANO CORTINA")
 * Fixed: Inline editor modal lost font selection state on close/reopen - selecting a font, closing the modal without applying, then reopening and clicking Apply would silently fail because stale state caused the apply logic to enter the wrong code path
 * Fixed: Missing data-lineheight attribute in format type registration - line-height values were silently dropped when reading back existing formatted content
 * Improved: Apply notice in the inline editor now includes a "Convert to a Typography Stylist block" link, guiding users toward the block type that supports real-time preview
 * Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
 * Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
+* Changed: "Edit Fallbacks" button renamed to "Edit Settings" in admin font management to reflect expanded functionality
 * Improved: OpenType feature previews now show cumulative checked features - toggling a stylistic set updates ALL preview windows to include that feature, accurately showing how features combine (essential for fonts like Bookmania where stylistic sets interact to produce different glyphs)
 
 = 1.2.0 =

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -2534,6 +2534,12 @@ class Typost {
             // Extract just the @font-face rules for this family from CSS
             $family_css = $this->extract_font_face_css($css_content, $family);
 
+            // Auto-detect available weights from font faces
+            $detected_weights = array_values(array_unique(array_map(function($face) {
+                return isset($face['weight']) ? $face['weight'] : '400';
+            }, $faces)));
+            sort($detected_weights);
+
             $font_entries[] = array(
                 'id' => sanitize_key($composite_font_id),
                 'name' => sanitize_text_field($family), // Use family name as font name
@@ -2542,6 +2548,7 @@ class Typost {
                 'kit_name' => sanitize_text_field($kit_name), // For display/grouping
                 'css_content' => $family_css,
                 'font_faces' => $faces,                  // Only this family's faces
+                'available_weights' => $this->sanitize_available_weights($detected_weights),
                 'upload_path' => $kit_base_path,         // Shared directory
                 'upload_url' => $kit_base_url,
                 'uploaded_date' => current_time('mysql')
@@ -3121,7 +3128,7 @@ class Typost {
         $id = sanitize_key($request->get_param('id'));
         $params = $request->get_json_params();
 
-        if (!isset($params['fallbacks'])) {
+        if (!isset($params['fallbacks']) && !isset($params['available_weights'])) {
             return new WP_Error('missing_fallbacks', esc_html__('Fallbacks parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
@@ -3130,7 +3137,12 @@ class Typost {
 
         foreach ($fonts as $key => $font) {
             if ($font['id'] === $id) {
-                $fonts[$key]['fallbacks'] = sanitize_text_field($params['fallbacks']);
+                if (isset($params['fallbacks'])) {
+                    $fonts[$key]['fallbacks'] = sanitize_text_field($params['fallbacks']);
+                }
+                if (isset($params['available_weights'])) {
+                    $fonts[$key]['available_weights'] = $this->sanitize_available_weights($params['available_weights']);
+                }
                 $found = true;
                 break;
             }
@@ -3199,7 +3211,7 @@ class Typost {
         $id = sanitize_key($request->get_param('id'));
         $params = $request->get_json_params();
 
-        if (!isset($params['fallbacks'])) {
+        if (!isset($params['fallbacks']) && !isset($params['available_weights'])) {
             return new WP_Error('missing_fallbacks', esc_html__('Fallbacks parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
@@ -3208,7 +3220,12 @@ class Typost {
 
         foreach ($fonts as $key => $font) {
             if ($font['id'] === $id) {
-                $fonts[$key]['fallbacks'] = sanitize_text_field($params['fallbacks']);
+                if (isset($params['fallbacks'])) {
+                    $fonts[$key]['fallbacks'] = sanitize_text_field($params['fallbacks']);
+                }
+                if (isset($params['available_weights'])) {
+                    $fonts[$key]['available_weights'] = $this->sanitize_available_weights($params['available_weights']);
+                }
                 $found = true;
                 break;
             }
@@ -3364,7 +3381,7 @@ class Typost {
         $id = sanitize_key($request->get_param('id'));
         $params = $request->get_json_params();
 
-        if (!isset($params['font_family'])) {
+        if (!isset($params['font_family']) && !isset($params['available_weights'])) {
             return new WP_Error('missing_font_family', esc_html__('Font family parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
@@ -3373,8 +3390,15 @@ class Typost {
 
         foreach ($fonts as $key => $font) {
             if ($font['id'] === $id) {
-                $fonts[$key]['font_family'] = sanitize_text_field($params['font_family']);
-                $fonts[$key]['fallbacks'] = isset($params['fallbacks']) ? sanitize_text_field($params['fallbacks']) : '';
+                if (isset($params['font_family'])) {
+                    $fonts[$key]['font_family'] = sanitize_text_field($params['font_family']);
+                }
+                if (isset($params['fallbacks'])) {
+                    $fonts[$key]['fallbacks'] = sanitize_text_field($params['fallbacks']);
+                }
+                if (isset($params['available_weights'])) {
+                    $fonts[$key]['available_weights'] = $this->sanitize_available_weights($params['available_weights']);
+                }
                 $found = true;
                 break;
             }
@@ -3853,7 +3877,7 @@ class Typost {
             if (isset($font['font_id']) && !empty($font['font_faces'][0])) {
                 // Use first face for main variable - sanitize for CSS context
                 $family = $this->sanitize_css_value($font['font_faces'][0]['family']);
-                $fallback = isset($font['fallbacks']) ? ', ' . $this->sanitize_css_value($font['fallbacks']) : '';
+                $fallback = !empty($font['fallbacks']) ? ', ' . $this->sanitize_css_value($font['fallbacks']) : '';
                 $css_vars[] = sprintf('--font-%d: "%s"%s', $font['font_id'], $family, $fallback);
             }
         }
@@ -3874,7 +3898,7 @@ class Typost {
                 }
 
                 if ($family) {
-                    $fallback = isset($font['fallbacks']) ? ', ' . $this->sanitize_css_value($font['fallbacks']) : '';
+                    $fallback = !empty($font['fallbacks']) ? ', ' . $this->sanitize_css_value($font['fallbacks']) : '';
                     $css_vars[] = sprintf('--font-%d: "%s"%s', $font['font_id'], $family, $fallback);
                 }
             }
@@ -4339,6 +4363,38 @@ class Typost {
 
         // Use CSS-specific sanitization
         return $this->sanitize_css_value($fallbacks);
+    }
+
+    /**
+     * Sanitize available font weights
+     *
+     * Validates and filters an array of font weight values against the standard
+     * CSS font-weight scale (100-900). Returns empty array if all 9 weights are
+     * provided (meaning "all weights available").
+     *
+     * @since 1.3.0
+     *
+     * @param mixed $weights Input weights array.
+     * @return array Sanitized array of weight strings, or empty array for "all weights".
+     */
+    private function sanitize_available_weights($weights) {
+        if (!is_array($weights)) {
+            return array();
+        }
+
+        $allowed = array('100', '200', '300', '400', '500', '600', '700', '800', '900');
+        $sanitized = array_values(array_intersect(
+            array_map('sanitize_text_field', $weights),
+            $allowed
+        ));
+
+        // If all 9 weights selected, store empty array (= "all weights available")
+        if (count($sanitized) === 9) {
+            return array();
+        }
+
+        sort($sanitized);
+        return $sanitized;
     }
 
     /**

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -3122,7 +3122,7 @@ class Typost {
         $params = $request->get_json_params();
 
         if (!isset($params['fallbacks']) && !isset($params['available_weights'])) {
-            return new WP_Error('missing_fallbacks', esc_html__('Fallbacks parameter is required', 'typography-stylist'), array('status' => 400));
+            return new WP_Error('missing_params', esc_html__('Either fallbacks or available_weights parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
         $fonts = $this->get_adobe_fonts();
@@ -3205,7 +3205,7 @@ class Typost {
         $params = $request->get_json_params();
 
         if (!isset($params['fallbacks']) && !isset($params['available_weights'])) {
-            return new WP_Error('missing_fallbacks', esc_html__('Fallbacks parameter is required', 'typography-stylist'), array('status' => 400));
+            return new WP_Error('missing_params', esc_html__('Either fallbacks or available_weights parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
         $fonts = $this->get_custom_fonts();
@@ -3375,7 +3375,7 @@ class Typost {
         $params = $request->get_json_params();
 
         if (!isset($params['font_family']) && !isset($params['available_weights'])) {
-            return new WP_Error('missing_font_family', esc_html__('Font family parameter is required', 'typography-stylist'), array('status' => 400));
+            return new WP_Error('missing_params', esc_html__('Either font_family or available_weights parameter is required', 'typography-stylist'), array('status' => 400));
         }
 
         $fonts = $this->get_manual_fonts();

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -2534,12 +2534,6 @@ class Typost {
             // Extract just the @font-face rules for this family from CSS
             $family_css = $this->extract_font_face_css($css_content, $family);
 
-            // Auto-detect available weights from font faces
-            $detected_weights = array_values(array_unique(array_map(function($face) {
-                return isset($face['weight']) ? $face['weight'] : '400';
-            }, $faces)));
-            sort($detected_weights);
-
             $font_entries[] = array(
                 'id' => sanitize_key($composite_font_id),
                 'name' => sanitize_text_field($family), // Use family name as font name
@@ -2548,7 +2542,6 @@ class Typost {
                 'kit_name' => sanitize_text_field($kit_name), // For display/grouping
                 'css_content' => $family_css,
                 'font_faces' => $faces,                  // Only this family's faces
-                'available_weights' => $this->sanitize_available_weights($detected_weights),
                 'upload_path' => $kit_base_path,         // Shared directory
                 'upload_url' => $kit_base_url,
                 'uploaded_date' => current_time('mysql')


### PR DESCRIPTION
Closes #94 

- Implemented per-font weight restrictions allowing configuration of available font weights in the admin panel (Settings → Typography Stylist → Custom Fonts).
- Introduced single-weight auto-apply feature, hiding the weight selector when only one weight is available and automatically applying it.
- Implemented weight validation on font change to adjust the weight to the closest available option.
- Updated admin UI to reflect changes, including renaming "Edit Fallbacks" to "Edit Settings" for clarity.
- Fixed CSS variable trailing comma issue that caused fonts without fallbacks to fail loading.
- Improved accessibility and user experience in the inline editor and font management sections.

This pull request introduces a new feature that allows restricting available font weights per font, improving both the admin UI and the block editor experience. The changes ensure that only the correct font weights can be selected for each font, provide utility functions and comprehensive tests for weight filtering, and update the UI to reflect these restrictions. Below are the most significant changes:

**Admin UI and Data Handling:**

* The admin page JavaScript now collects selected available font weights when saving font settings for all font types (custom, Adobe, manual), sending them to the backend as the `available_weights` property. [[1]](diffhunk://#diff-da17bb06f0b71c18c492b2116430a2d5efd2391fd081bd24bf2fd5ae249ec3b2R658-R669) [[2]](diffhunk://#diff-da17bb06f0b71c18c492b2116430a2d5efd2391fd081bd24bf2fd5ae249ec3b2R722-R733) [[3]](diffhunk://#diff-da17bb06f0b71c18c492b2116430a2d5efd2391fd081bd24bf2fd5ae249ec3b2R784-R787) [[4]](diffhunk://#diff-da17bb06f0b71c18c492b2116430a2d5efd2391fd081bd24bf2fd5ae249ec3b2L794-R807)
* New CSS classes were added to style the font weight checkboxes in the admin interface, improving usability for selecting available weights.

**Block Editor Logic and UI:**

* The block editor's internal `fontIdMap` now stores an `availableWeights` array for each font, populated from the backend, allowing the editor to know which weights are valid for each font. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1516-R1530) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1533-R1547) [[3]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1544-R1558) [[4]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1560-R1632) [[5]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL1011-R1011) [[6]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL1026-R1026) [[7]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL1037-R1037)
* When a user selects a font in the block editor, the editor now checks if the current weight is valid for that font. If not, it automatically selects the closest available weight, or the only available weight if there is just one.
* The font weight dropdown in the block editor is dynamically filtered to only show the allowed weights for the selected font. If a font has only one available weight, the dropdown is hidden.

**Utility Functions and Testing:**

* Utility functions `getFilteredWeightOptions` and `getClosestWeight` were added to filter weight options and find the closest valid weight, respectively. These are used in both the block editor and are exposed for unit testing. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1560-R1632) [[2]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL32-R32)
* A comprehensive test suite was added to validate the behavior of weight filtering and closest weight selection logic, ensuring robust handling of all edge cases.