### PR TITLE
Bump version number, fix warning for undefined array key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typost",
-  "version": "1.1.9",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typost",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/cli": "^7.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typost",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "WordPress plugin for advanced OpenType typography features in Gutenberg headlines",
   "scripts": {
     "build": "npm run build:block && npm run build:js && npm run build:css",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matthewneilcowan
 Tags: typography, opentype, ligatures, stylistic-sets, webfonts
 Requires at least: 5.8
 Tested up to: 6.9.1
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -3,7 +3,7 @@
  * Plugin Name: Typography Stylist
  * Plugin URI: https://wordpress.org/plugins/typography-stylist/
  * Description: Add advanced OpenType features (ligatures, stylistic sets, swashes) to headlines with inline text selection and live preview.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Matthew Cowan
  * Author URI: https://mnc4.com
  * License: GPL v2 or later
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 
 // Define plugin constants (check if already defined for test compatibility)
 if (!defined('TYPOST_VERSION')) {
-    define('TYPOST_VERSION', '1.2.0');
+    define('TYPOST_VERSION', '1.2.1');
 }
 if (!defined('TYPOST_PLUGIN_DIR')) {
     define('TYPOST_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -811,7 +811,11 @@ class Typost {
         }
 
         // Build cache key including load_on_all_pages settings
-        $load_settings = wp_list_pluck($all_fonts, 'load_on_all_pages', 'id');
+        $load_settings = array();
+        foreach ($all_fonts as $font) {
+            $font_id = isset($font['id']) ? $font['id'] : '';
+            $load_settings[$font_id] = !empty($font['load_on_all_pages']);
+        }
         $cache_key = 'typost_font_css_' . md5(serialize($used_font_families) . serialize($load_settings));
         $combined_css = get_transient($cache_key);
 


### PR DESCRIPTION
This pull request updates the plugin version from 1.2.0 to 1.2.1 across all relevant files and includes a minor code improvement related to how font loading settings are processed for caching. The main focus is on version bumping for release and a small bug fix or enhancement in the font loading logic.

Version updates:

* Updated the version number to 1.2.1 in `package.json`, `readme.txt`, and in the plugin header and constant definition within `typography-stylist.php`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-8477ec8a3f90e1acada6ac3df511bfaf7e7b3e9ee35435851a2affcbd939737cL6-R6) [[4]](diffhunk://#diff-8477ec8a3f90e1acada6ac3df511bfaf7e7b3e9ee35435851a2affcbd939737cL24-R24)

Bug fix / code improvement:

* Changed how the `$load_settings` array is built in the `enqueue_custom_fonts_optimized` method of `typography-stylist.php` to ensure proper handling of font IDs and boolean values, which improves cache key generation and potentially fixes issues with font loading settings.