### PR TITLE
feat: Expand OpenType feature support to 52 features, bugfix for apply/unapply features in Typography Stylist block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ All endpoints include:
 
 ### Available OpenType Features
 
-The plugin supports these feature categories (52 features total):
+The plugin supports these feature categories (51 features total):
 - **Ligatures:** liga, dlig, calt, clig, hlig
 - **Stylistic Sets:** ss01-ss20
 - **Swashes & Alternates:** swsh, cswh, salt, titl, hist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,12 +175,18 @@ All endpoints include:
 
 ### Available OpenType Features
 
-The plugin supports these feature categories:
-- **Ligatures:** liga, dlig, calt
-- **Stylistic Sets:** ss01-ss05 (hardcoded, but supports through ss20)
-- **Alternates:** swsh, cswh, salt, titl, ornm
+The plugin supports these feature categories (52 features total):
+- **Ligatures:** liga, dlig, calt, clig, hlig
+- **Stylistic Sets:** ss01-ss20
+- **Swashes & Alternates:** swsh, cswh, salt, titl, hist
+- **Decorative:** ornm
+- **Numerals & Figures:** pnum, tnum, lnum, onum, frac, zero
+- **Capitals & Case:** smcp, c2sc, pcap, case
+- **Positional Forms:** init, medi, fina, isol
+- **Superscript & Ordinals:** sups, subs, ordn
+- **Other Features:** kern, locl, rand
 
-Feature data structure in [typography-stylist.php](typography-stylist.php:247-328):
+Feature data structure in [typography-stylist.php](typography-stylist.php):
 ```php
 array(
     'id' => 'calt',           // OpenType feature code

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ A WordPress plugin that adds advanced OpenType typography features to headlines 
 
 ## Features
 
-### Typography Control
-- Ligatures: Standard (liga), Discretionary (dlig), Contextual Alternates (calt)
+### Typography Control (52 OpenType Features)
+- Ligatures: Standard (liga), Discretionary (dlig), Contextual Alternates (calt), Contextual Ligatures (clig), Historical Ligatures (hlig)
 - Stylistic Sets: ss01 through ss20
-- Swashes: Regular (swsh) and Contextual (cswh)
-- Alternates: Stylistic alternates (salt), Titling (titl), Ornaments (ornm)
+- Swashes & Alternates: Swashes (swsh), Contextual Swashes (cswh), Stylistic Alternates (salt), Titling (titl), Historical Forms (hist)
+- Decorative: Ornaments (ornm)
+- Numerals & Figures: Proportional (pnum), Tabular (tnum), Lining (lnum), Oldstyle (onum), Fractions (frac), Slashed Zero (zero)
+- Capitals & Case: Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
+- Positional Forms: Initial (init), Medial (medi), Terminal (fina), Isolated (isol)
+- Superscript & Ordinals: Superscript (sups), Subscript (subs), Ordinals (ordn)
+- Other: Kerning (kern), Localized Forms (locl), Randomize (rand)
 
 ### User Interface
 - Inline text selection in the block editor
@@ -349,6 +354,21 @@ The plugin is designed for the WordPress block editor (Gutenberg). Compatibility
 The plugin uses native CSS `font-feature-settings` which is hardware-accelerated in modern browsers. Performance impact depends on font file sizes and loading strategy. The plugin includes JavaScript in the block editor but uses only CSS for frontend rendering.
 
 ## Changelog
+
+### Version 1.2.2
+
+**New OpenType Features:**
+- **Added: 23 new OpenType features** across 5 new categories, bringing the total from 29 to 52 supported features
+- **Added: Numerals & Figures category** - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
+- **Added: Capitals & Case category** - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
+- **Added: Positional Forms category** - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)
+- **Added: Superscript & Ordinals category** - Superscript (sups), Subscript (subs), Ordinals (ordn)
+- **Added: Other Features category** - Kerning (kern), Localized Forms (locl), Randomize (rand)
+- **Added: Contextual Ligatures (clig) and Historical Ligatures (hlig)** to the existing Ligatures category
+- **Added: Historical Forms (hist)** to the existing Swashes & Alternates category
+
+**Bug Fix:**
+- **Fixed: Unchecking OpenType feature removed other inline properties** - In the Quick Features Toggle, unchecking an OpenType feature would strip font-family, font-weight, and other properties from the styled span. The `removeFeatureFromSelection()` function was unconditionally unwrapping spans when no features remained, even when the span still had other data attributes (`data-font-id`, `data-fontweight`, etc.). The fix checks for remaining attributes before deciding whether to unwrap, following the same pattern used in `removePropertyFromSpan()`.
 
 ### Version 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A WordPress plugin that adds advanced OpenType typography features to headlines 
 
 ## Features
 
-### Typography Control (52 OpenType Features)
+### Typography Control (51 OpenType Features)
 - Ligatures: Standard (liga), Discretionary (dlig), Contextual Alternates (calt), Contextual Ligatures (clig), Historical Ligatures (hlig)
 - Stylistic Sets: ss01 through ss20
 - Swashes & Alternates: Swashes (swsh), Contextual Swashes (cswh), Stylistic Alternates (salt), Titling (titl), Historical Forms (hist)
@@ -358,7 +358,7 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 ### Version 1.2.2
 
 **New OpenType Features:**
-- **Added: 23 new OpenType features** across 5 new categories, bringing the total from 29 to 52 supported features
+- **Added: 23 new OpenType features** across 5 new categories, bringing the total from 28 to 51 supported features
 - **Added: Numerals & Figures category** - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
 - **Added: Capitals & Case category** - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
 - **Added: Positional Forms category** - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -2471,6 +2471,10 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 'stylistic-sets': __('Stylistic Sets', 'typography-stylist'),
                 'alternates': __('Swashes & Alternates', 'typography-stylist'),
                 'decorative': __('Decorative', 'typography-stylist'),
+                'numerals': __('Numerals & Figures', 'typography-stylist'),
+                'capitals': __('Capitals & Case', 'typography-stylist'),
+                'positional': __('Positional Forms', 'typography-stylist'),
+                'super-sub': __('Superscript & Ordinals', 'typography-stylist'),
                 'other': __('Other Features', 'typography-stylist')
             };
 

--- a/blocks/typography-stylist/edit.js
+++ b/blocks/typography-stylist/edit.js
@@ -1937,12 +1937,47 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 							const featureList = dataFeatures.split(',').map(f => f.trim()).filter(f => f && f !== featureId);
 
 							if (featureList.length === 0) {
-								// No features left - unwrap the span
-								if (span.parentNode) {
-									while (span.firstChild) {
-										span.parentNode.insertBefore(span.firstChild, span);
+								// No features left - remove data-features attribute
+								span.removeAttribute('data-features');
+
+								// Remove font-feature-settings from style, keep other styles
+								const currentStyleForRemoval = span.getAttribute('style') || '';
+								const remainingStyleObj = {};
+								currentStyleForRemoval.split(';').forEach(rule => {
+									const [prop, value] = rule.split(':').map(s => s.trim());
+									if (prop && value && prop !== 'font-feature-settings') {
+										remainingStyleObj[prop] = value;
 									}
-									span.parentNode.removeChild(span);
+								});
+
+								// Rebuild style or remove it entirely
+								if (Object.keys(remainingStyleObj).length > 0) {
+									const newStyle = Object.entries(remainingStyleObj)
+										.map(([prop, value]) => `${prop}: ${value}`)
+										.join('; ');
+									span.setAttribute('style', newStyle);
+								} else {
+									span.removeAttribute('style');
+								}
+
+								// Check if any other typost attributes remain before unwrapping
+								const hasFontId = span.getAttribute('data-font-id');
+								const hasFontSize = span.getAttribute('data-fontsize');
+								const hasFontWeight = span.getAttribute('data-fontweight');
+								const hasLetterSpacing = span.getAttribute('data-letterspacing');
+								const hasLineHeight = span.getAttribute('data-lineheight');
+
+								const hasAnyAttributes = hasFontId || hasFontSize ||
+								                         hasFontWeight || hasLetterSpacing || hasLineHeight;
+
+								if (!hasAnyAttributes && Object.keys(remainingStyleObj).length === 0) {
+									// No attributes or styles remain - safe to unwrap the span
+									if (span.parentNode) {
+										while (span.firstChild) {
+											span.parentNode.insertBefore(span.firstChild, span);
+										}
+										span.parentNode.removeChild(span);
+									}
 								}
 							} else {
 								// Update the span with remaining features (comma-separated)
@@ -2094,6 +2129,10 @@ export default function Edit({ attributes, setAttributes, clientId }) {
 			'stylistic-sets': __('Stylistic Sets', 'typography-stylist'),
 			'alternates': __('Swashes & Alternates', 'typography-stylist'),
 			'decorative': __('Decorative', 'typography-stylist'),
+			'numerals': __('Numerals & Figures', 'typography-stylist'),
+			'capitals': __('Capitals & Case', 'typography-stylist'),
+			'positional': __('Positional Forms', 'typography-stylist'),
+			'super-sub': __('Superscript & Ordinals', 'typography-stylist'),
 			'other': __('Other Features', 'typography-stylist')
 		};
 		return titles[category] || category;

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -284,7 +284,12 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                 'ligatures' => esc_html__('Ligatures', 'typography-stylist'),
                 'stylistic-sets' => esc_html__('Stylistic Sets', 'typography-stylist'),
                 'alternates' => esc_html__('Swashes & Alternates', 'typography-stylist'),
-                'decorative' => esc_html__('Decorative', 'typography-stylist')
+                'decorative' => esc_html__('Decorative', 'typography-stylist'),
+                'numerals' => esc_html__('Numerals & Figures', 'typography-stylist'),
+                'capitals' => esc_html__('Capitals & Case', 'typography-stylist'),
+                'positional' => esc_html__('Positional Forms', 'typography-stylist'),
+                'super-sub' => esc_html__('Superscript & Ordinals', 'typography-stylist'),
+                'other' => esc_html__('Other Features', 'typography-stylist')
             );
             ?>
 

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -237,6 +237,214 @@ msgstr "Ornamentos"
 msgid "Decorative ornaments"
 msgstr "Ornamentos decorativos"
 
+#: typography-stylist.php
+msgid "Contextual Ligatures"
+msgstr "Ligaduras contextuales"
+
+#: typography-stylist.php
+msgid "Context-dependent ligature substitutions"
+msgstr "Sustituciones de ligaduras dependientes del contexto"
+
+#: typography-stylist.php
+msgid "Historical Ligatures"
+msgstr "Ligaduras históricas"
+
+#: typography-stylist.php
+msgid "Archaic and historical ligature forms"
+msgstr "Formas de ligaduras arcaicas e históricas"
+
+#: typography-stylist.php
+msgid "Historical Forms"
+msgstr "Formas históricas"
+
+#: typography-stylist.php
+msgid "Archaic and historical letterforms"
+msgstr "Formas de letras arcaicas e históricas"
+
+#: typography-stylist.php
+msgid "Proportional Figures"
+msgstr "Cifras proporcionales"
+
+#: typography-stylist.php
+msgid "Variable-width number spacing"
+msgstr "Espaciado de números de ancho variable"
+
+#: typography-stylist.php
+msgid "Tabular Figures"
+msgstr "Cifras tabulares"
+
+#: typography-stylist.php
+msgid "Fixed-width number spacing for alignment"
+msgstr "Espaciado de números de ancho fijo para alineación"
+
+#: typography-stylist.php
+msgid "Lining Figures"
+msgstr "Cifras alineadas"
+
+#: typography-stylist.php
+msgid "Numbers aligned to the baseline"
+msgstr "Números alineados a la línea base"
+
+#: typography-stylist.php
+msgid "Oldstyle Figures"
+msgstr "Cifras de estilo antiguo"
+
+#: typography-stylist.php
+msgid "Numbers with varying heights and descenders"
+msgstr "Números con alturas variables y descendentes"
+
+#: typography-stylist.php
+msgid "Fractions"
+msgstr "Fracciones"
+
+#: typography-stylist.php
+msgid "Automatic fraction formation"
+msgstr "Formación automática de fracciones"
+
+#: typography-stylist.php
+msgid "Slashed Zero"
+msgstr "Cero con barra"
+
+#: typography-stylist.php
+msgid "Zero with slash to distinguish from letter O"
+msgstr "Cero con barra para distinguirlo de la letra O"
+
+#: typography-stylist.php
+msgid "Small Capitals"
+msgstr "Versalitas"
+
+#: typography-stylist.php
+msgid "Lowercase letters as small capital forms"
+msgstr "Letras minúsculas como versalitas"
+
+#: typography-stylist.php
+msgid "Capitals to Small Caps"
+msgstr "Mayúsculas a versalitas"
+
+#: typography-stylist.php
+msgid "Convert uppercase letters to small capitals"
+msgstr "Convertir letras mayúsculas a versalitas"
+
+#: typography-stylist.php
+msgid "Petite Capitals"
+msgstr "Capitales pequeñas"
+
+#: typography-stylist.php
+msgid "Smaller than small capitals, matching x-height"
+msgstr "Más pequeñas que las versalitas, coincidiendo con la altura de x"
+
+#: typography-stylist.php
+msgid "Case-Sensitive Forms"
+msgstr "Formas sensibles a mayúsculas"
+
+#: typography-stylist.php
+msgid "Punctuation and symbols adjusted for all-caps text"
+msgstr "Puntuación y símbolos ajustados para texto en mayúsculas"
+
+#: typography-stylist.php
+msgid "Initial Forms"
+msgstr "Formas iniciales"
+
+#: typography-stylist.php
+msgid "Letterforms used at the beginning of a word"
+msgstr "Formas de letras usadas al inicio de una palabra"
+
+#: typography-stylist.php
+msgid "Medial Forms"
+msgstr "Formas mediales"
+
+#: typography-stylist.php
+msgid "Letterforms used in the middle of a word"
+msgstr "Formas de letras usadas en el medio de una palabra"
+
+#: typography-stylist.php
+msgid "Terminal Forms"
+msgstr "Formas terminales"
+
+#: typography-stylist.php
+msgid "Letterforms used at the end of a word"
+msgstr "Formas de letras usadas al final de una palabra"
+
+#: typography-stylist.php
+msgid "Isolated Forms"
+msgstr "Formas aisladas"
+
+#: typography-stylist.php
+msgid "Standalone letterforms not connected to adjacent characters"
+msgstr "Formas de letras independientes no conectadas a caracteres adyacentes"
+
+#: typography-stylist.php
+msgid "Superscript"
+msgstr "Superíndice"
+
+#: typography-stylist.php
+msgid "Raised characters for footnotes and exponents"
+msgstr "Caracteres elevados para notas al pie y exponentes"
+
+#: typography-stylist.php
+msgid "Subscript"
+msgstr "Subíndice"
+
+#: typography-stylist.php
+msgid "Lowered characters for chemical formulas and indices"
+msgstr "Caracteres reducidos para fórmulas químicas e índices"
+
+#: typography-stylist.php
+msgid "Ordinals"
+msgstr "Ordinales"
+
+#: typography-stylist.php
+msgid "Ordinal indicators like 1st, 2nd, 3rd"
+msgstr "Indicadores ordinales como 1.º, 2.º, 3.º"
+
+#: typography-stylist.php
+msgid "Kerning"
+msgstr "Interletraje"
+
+#: typography-stylist.php
+msgid "Fine-tuned letter spacing adjustments"
+msgstr "Ajustes finos del espaciado entre letras"
+
+#: typography-stylist.php
+msgid "Localized Forms"
+msgstr "Formas localizadas"
+
+#: typography-stylist.php
+msgid "Script and language-specific character variants"
+msgstr "Variantes de caracteres específicas del idioma y la escritura"
+
+#: typography-stylist.php
+msgid "Randomize"
+msgstr "Aleatorizar"
+
+#: typography-stylist.php
+msgid "Randomized glyph variants for handwriting and calligraphic fonts"
+msgstr "Variantes de glifos aleatorias para fuentes manuscritas y caligráficas"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Numerals & Figures"
+msgstr "Números y cifras"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Capitals & Case"
+msgstr "Capitales y caja"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Positional Forms"
+msgstr "Formas posicionales"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Superscript & Ordinals"
+msgstr "Superíndices y ordinales"
+
 #: headline-ligatures-styles.php:871
 msgid "Missing required parameters"
 msgstr "Faltan parámetros requeridos"

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -237,6 +237,214 @@ msgstr "Ornements"
 msgid "Decorative ornaments"
 msgstr "Ornements décoratifs"
 
+#: typography-stylist.php
+msgid "Contextual Ligatures"
+msgstr "Ligatures contextuelles"
+
+#: typography-stylist.php
+msgid "Context-dependent ligature substitutions"
+msgstr "Substitutions de ligatures dépendantes du contexte"
+
+#: typography-stylist.php
+msgid "Historical Ligatures"
+msgstr "Ligatures historiques"
+
+#: typography-stylist.php
+msgid "Archaic and historical ligature forms"
+msgstr "Formes de ligatures archaïques et historiques"
+
+#: typography-stylist.php
+msgid "Historical Forms"
+msgstr "Formes historiques"
+
+#: typography-stylist.php
+msgid "Archaic and historical letterforms"
+msgstr "Formes de lettres archaïques et historiques"
+
+#: typography-stylist.php
+msgid "Proportional Figures"
+msgstr "Chiffres proportionnels"
+
+#: typography-stylist.php
+msgid "Variable-width number spacing"
+msgstr "Espacement de chiffres à largeur variable"
+
+#: typography-stylist.php
+msgid "Tabular Figures"
+msgstr "Chiffres tabulaires"
+
+#: typography-stylist.php
+msgid "Fixed-width number spacing for alignment"
+msgstr "Espacement de chiffres à largeur fixe pour l'alignement"
+
+#: typography-stylist.php
+msgid "Lining Figures"
+msgstr "Chiffres alignés"
+
+#: typography-stylist.php
+msgid "Numbers aligned to the baseline"
+msgstr "Chiffres alignés sur la ligne de base"
+
+#: typography-stylist.php
+msgid "Oldstyle Figures"
+msgstr "Chiffres elzéviriens"
+
+#: typography-stylist.php
+msgid "Numbers with varying heights and descenders"
+msgstr "Chiffres avec hauteurs variables et jambages"
+
+#: typography-stylist.php
+msgid "Fractions"
+msgstr "Fractions"
+
+#: typography-stylist.php
+msgid "Automatic fraction formation"
+msgstr "Formation automatique de fractions"
+
+#: typography-stylist.php
+msgid "Slashed Zero"
+msgstr "Zéro barré"
+
+#: typography-stylist.php
+msgid "Zero with slash to distinguish from letter O"
+msgstr "Zéro avec barre pour le distinguer de la lettre O"
+
+#: typography-stylist.php
+msgid "Small Capitals"
+msgstr "Petites capitales"
+
+#: typography-stylist.php
+msgid "Lowercase letters as small capital forms"
+msgstr "Lettres minuscules sous forme de petites capitales"
+
+#: typography-stylist.php
+msgid "Capitals to Small Caps"
+msgstr "Capitales en petites capitales"
+
+#: typography-stylist.php
+msgid "Convert uppercase letters to small capitals"
+msgstr "Convertir les lettres majuscules en petites capitales"
+
+#: typography-stylist.php
+msgid "Petite Capitals"
+msgstr "Capitales miniatures"
+
+#: typography-stylist.php
+msgid "Smaller than small capitals, matching x-height"
+msgstr "Plus petites que les petites capitales, correspondant à la hauteur d'x"
+
+#: typography-stylist.php
+msgid "Case-Sensitive Forms"
+msgstr "Formes sensibles à la casse"
+
+#: typography-stylist.php
+msgid "Punctuation and symbols adjusted for all-caps text"
+msgstr "Ponctuation et symboles ajustés pour le texte en majuscules"
+
+#: typography-stylist.php
+msgid "Initial Forms"
+msgstr "Formes initiales"
+
+#: typography-stylist.php
+msgid "Letterforms used at the beginning of a word"
+msgstr "Formes de lettres utilisées au début d'un mot"
+
+#: typography-stylist.php
+msgid "Medial Forms"
+msgstr "Formes médianes"
+
+#: typography-stylist.php
+msgid "Letterforms used in the middle of a word"
+msgstr "Formes de lettres utilisées au milieu d'un mot"
+
+#: typography-stylist.php
+msgid "Terminal Forms"
+msgstr "Formes terminales"
+
+#: typography-stylist.php
+msgid "Letterforms used at the end of a word"
+msgstr "Formes de lettres utilisées à la fin d'un mot"
+
+#: typography-stylist.php
+msgid "Isolated Forms"
+msgstr "Formes isolées"
+
+#: typography-stylist.php
+msgid "Standalone letterforms not connected to adjacent characters"
+msgstr "Formes de lettres autonomes non connectées aux caractères adjacents"
+
+#: typography-stylist.php
+msgid "Superscript"
+msgstr "Exposant"
+
+#: typography-stylist.php
+msgid "Raised characters for footnotes and exponents"
+msgstr "Caractères surélevés pour les notes de bas de page et les exposants"
+
+#: typography-stylist.php
+msgid "Subscript"
+msgstr "Indice"
+
+#: typography-stylist.php
+msgid "Lowered characters for chemical formulas and indices"
+msgstr "Caractères abaissés pour les formules chimiques et les indices"
+
+#: typography-stylist.php
+msgid "Ordinals"
+msgstr "Ordinaux"
+
+#: typography-stylist.php
+msgid "Ordinal indicators like 1st, 2nd, 3rd"
+msgstr "Indicateurs ordinaux comme 1er, 2e, 3e"
+
+#: typography-stylist.php
+msgid "Kerning"
+msgstr "Crénage"
+
+#: typography-stylist.php
+msgid "Fine-tuned letter spacing adjustments"
+msgstr "Ajustements fins de l'espacement des lettres"
+
+#: typography-stylist.php
+msgid "Localized Forms"
+msgstr "Formes localisées"
+
+#: typography-stylist.php
+msgid "Script and language-specific character variants"
+msgstr "Variantes de caractères spécifiques à l'écriture et à la langue"
+
+#: typography-stylist.php
+msgid "Randomize"
+msgstr "Aléatoire"
+
+#: typography-stylist.php
+msgid "Randomized glyph variants for handwriting and calligraphic fonts"
+msgstr "Variantes de glyphes aléatoires pour les polices manuscrites et calligraphiques"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Numerals & Figures"
+msgstr "Chiffres et figures"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Capitals & Case"
+msgstr "Capitales et casse"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Positional Forms"
+msgstr "Formes positionnelles"
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Superscript & Ordinals"
+msgstr "Exposants et ordinaux"
+
 #: headline-ligatures-styles.php:871
 msgid "Missing required parameters"
 msgstr "Paramètres obligatoires manquants"

--- a/languages/typography-stylist.pot
+++ b/languages/typography-stylist.pot
@@ -239,6 +239,214 @@ msgstr ""
 msgid "Decorative ornaments"
 msgstr ""
 
+#: typography-stylist.php
+msgid "Contextual Ligatures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Context-dependent ligature substitutions"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Historical Ligatures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Archaic and historical ligature forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Historical Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Archaic and historical letterforms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Proportional Figures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Variable-width number spacing"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Tabular Figures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Fixed-width number spacing for alignment"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Lining Figures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Numbers aligned to the baseline"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Oldstyle Figures"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Numbers with varying heights and descenders"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Fractions"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Automatic fraction formation"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Slashed Zero"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Zero with slash to distinguish from letter O"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Small Capitals"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Lowercase letters as small capital forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Capitals to Small Caps"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Convert uppercase letters to small capitals"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Petite Capitals"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Smaller than small capitals, matching x-height"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Case-Sensitive Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Punctuation and symbols adjusted for all-caps text"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Initial Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Letterforms used at the beginning of a word"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Medial Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Letterforms used in the middle of a word"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Terminal Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Letterforms used at the end of a word"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Isolated Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Standalone letterforms not connected to adjacent characters"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Superscript"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Raised characters for footnotes and exponents"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Subscript"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Lowered characters for chemical formulas and indices"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Ordinals"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Ordinal indicators like 1st, 2nd, 3rd"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Kerning"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Fine-tuned letter spacing adjustments"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Localized Forms"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Script and language-specific character variants"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Randomize"
+msgstr ""
+
+#: typography-stylist.php
+msgid "Randomized glyph variants for handwriting and calligraphic fonts"
+msgstr ""
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Numerals & Figures"
+msgstr ""
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Capitals & Case"
+msgstr ""
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Positional Forms"
+msgstr ""
+
+#: includes/admin-page.php
+#: blocks/typography-stylist/edit.js
+#: assets/js/block-editor.js
+msgid "Superscript & Ordinals"
+msgstr ""
+
 #: opentype-stylist.php:871
 msgid "Missing required parameters"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -268,7 +268,7 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 == Changelog ==
 
 = 1.2.2 =
-* Added: 23 new OpenType features across 5 new categories, bringing the total to 52 supported features
+* Added: 23 new OpenType features across 5 new categories, bringing the total to 51 supported features
 * Added: Numerals & Figures category - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
 * Added: Capitals & Case category - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
 * Added: Positional Forms category - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,8 @@ Accessibility features ensure that your styled text remains readable by screen r
 * Standard Ligatures (liga)
 * Discretionary Ligatures (dlig)
 * Contextual Alternates (calt)
+* Contextual Ligatures (clig)
+* Historical Ligatures (hlig)
 
 **Stylistic Sets:**
 * ss01 through ss20
@@ -49,7 +51,40 @@ Accessibility features ensure that your styled text remains readable by screen r
 * Contextual Swashes (cswh)
 * Stylistic Alternates (salt)
 * Titling (titl)
+* Historical Forms (hist)
+
+**Decorative:**
 * Ornaments (ornm)
+
+**Numerals & Figures:**
+* Proportional Figures (pnum)
+* Tabular Figures (tnum)
+* Lining Figures (lnum)
+* Oldstyle Figures (onum)
+* Fractions (frac)
+* Slashed Zero (zero)
+
+**Capitals & Case:**
+* Small Capitals (smcp)
+* Capitals to Small Caps (c2sc)
+* Petite Capitals (pcap)
+* Case-Sensitive Forms (case)
+
+**Positional Forms:**
+* Initial Forms (init)
+* Medial Forms (medi)
+* Terminal Forms (fina)
+* Isolated Forms (isol)
+
+**Superscript & Ordinals:**
+* Superscript (sups)
+* Subscript (subs)
+* Ordinals (ordn)
+
+**Other Features:**
+* Kerning (kern)
+* Localized Forms (locl)
+* Randomize (rand)
 
 = Perfect For =
 
@@ -231,6 +266,17 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 5. Typography Stylist Block with Quick Feature Toggle open to apply stylistic sets and other features
 
 == Changelog ==
+
+= 1.2.2 =
+* Added: 23 new OpenType features across 5 new categories, bringing the total to 52 supported features
+* Added: Numerals & Figures category - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
+* Added: Capitals & Case category - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
+* Added: Positional Forms category - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)
+* Added: Superscript & Ordinals category - Superscript (sups), Subscript (subs), Ordinals (ordn)
+* Added: Other Features category - Kerning (kern), Localized Forms (locl), Randomize (rand)
+* Added: Contextual Ligatures (clig) and Historical Ligatures (hlig) to Ligatures category
+* Added: Historical Forms (hist) to Swashes & Alternates category
+* Fixed: Unchecking an OpenType feature in the Quick Features Toggle removed font-family, font-weight, and other properties from the styled text. The feature removal code now preserves all other data attributes and styles on the span, only unwrapping it when no attributes remain
 
 = 1.2.1 =
 * Added: Per-font weight restrictions - configure which font weights are available for each font in the admin panel (Settings → Typography Stylist → Custom Fonts). Fonts default to all weights for variable font compatibility

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -1432,7 +1432,42 @@ class Typost {
             'cswh' => 'Beautiful Swashes',
             'salt' => 'Alternative Glyphs',
             'titl' => 'TITLING CAPS',
-            'ornm' => '* § ¶ † ‡ • ◆'
+            'hist' => 'Long ſ and hiſtoric',
+            'ornm' => '* § ¶ † ‡ • ◆',
+
+            // Additional Ligatures
+            'clig' => 'ffi ffl ct st',
+            'hlig' => 'ct ſt ſi ſl',
+
+            // Numerals & Figures
+            'pnum' => '0123456789',
+            'tnum' => '0123456789',
+            'lnum' => '0123456789',
+            'onum' => '0123456789',
+            'frac' => '1/2 3/4 5/8 7/16',
+            'zero' => 'O0 l1 Z2 S5',
+
+            // Capitals & Case
+            'smcp' => 'Small Capitals',
+            'c2sc' => 'CAPITALS TO SMALL CAPS',
+            'pcap' => 'Petite Capitals',
+            'case' => 'H[A]R{D} (CAPS)',
+
+            // Positional Forms
+            'init' => 'Initial',
+            'medi' => 'Medium',
+            'fina' => 'Final',
+            'isol' => 'Isolated',
+
+            // Superscript & Ordinals
+            'sups' => 'H2O x2 1st',
+            'subs' => 'H2O CO2 x1',
+            'ordn' => '1st 2nd 3rd 4th',
+
+            // Other Features
+            'kern' => 'AV To WA Ty',
+            'locl' => 'Localized Forms',
+            'rand' => 'Handwritten Style'
         );
 
         return isset($demo_texts[$feature_id]) ? $demo_texts[$feature_id] : 'Sample Text';
@@ -1461,6 +1496,18 @@ class Typost {
                     'name' => esc_html__('Contextual Alternates', 'typography-stylist'),
                     'category' => 'ligatures',
                     'description' => esc_html__('Context-aware letter forms', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'clig',
+                    'name' => esc_html__('Contextual Ligatures', 'typography-stylist'),
+                    'category' => 'ligatures',
+                    'description' => esc_html__('Context-dependent ligature substitutions', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'hlig',
+                    'name' => esc_html__('Historical Ligatures', 'typography-stylist'),
+                    'category' => 'ligatures',
+                    'description' => esc_html__('Archaic and historical ligature forms', 'typography-stylist')
                 ),
                 array(
                     'id' => 'ss01',
@@ -1607,10 +1654,141 @@ class Typost {
                     'description' => esc_html__('Optimized for large titles', 'typography-stylist')
                 ),
                 array(
+                    'id' => 'hist',
+                    'name' => esc_html__('Historical Forms', 'typography-stylist'),
+                    'category' => 'alternates',
+                    'description' => esc_html__('Archaic and historical letterforms', 'typography-stylist')
+                ),
+                array(
                     'id' => 'ornm',
                     'name' => esc_html__('Ornaments', 'typography-stylist'),
                     'category' => 'decorative',
                     'description' => esc_html__('Decorative ornaments', 'typography-stylist')
+                ),
+                // Numerals & Figures
+                array(
+                    'id' => 'pnum',
+                    'name' => esc_html__('Proportional Figures', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Variable-width number spacing', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'tnum',
+                    'name' => esc_html__('Tabular Figures', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Fixed-width number spacing for alignment', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'lnum',
+                    'name' => esc_html__('Lining Figures', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Numbers aligned to the baseline', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'onum',
+                    'name' => esc_html__('Oldstyle Figures', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Numbers with varying heights and descenders', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'frac',
+                    'name' => esc_html__('Fractions', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Automatic fraction formation', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'zero',
+                    'name' => esc_html__('Slashed Zero', 'typography-stylist'),
+                    'category' => 'numerals',
+                    'description' => esc_html__('Zero with slash to distinguish from letter O', 'typography-stylist')
+                ),
+                // Capitals & Case
+                array(
+                    'id' => 'smcp',
+                    'name' => esc_html__('Small Capitals', 'typography-stylist'),
+                    'category' => 'capitals',
+                    'description' => esc_html__('Lowercase letters as small capital forms', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'c2sc',
+                    'name' => esc_html__('Capitals to Small Caps', 'typography-stylist'),
+                    'category' => 'capitals',
+                    'description' => esc_html__('Convert uppercase letters to small capitals', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'pcap',
+                    'name' => esc_html__('Petite Capitals', 'typography-stylist'),
+                    'category' => 'capitals',
+                    'description' => esc_html__('Smaller than small capitals, matching x-height', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'case',
+                    'name' => esc_html__('Case-Sensitive Forms', 'typography-stylist'),
+                    'category' => 'capitals',
+                    'description' => esc_html__('Punctuation and symbols adjusted for all-caps text', 'typography-stylist')
+                ),
+                // Positional Forms
+                array(
+                    'id' => 'init',
+                    'name' => esc_html__('Initial Forms', 'typography-stylist'),
+                    'category' => 'positional',
+                    'description' => esc_html__('Letterforms used at the beginning of a word', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'medi',
+                    'name' => esc_html__('Medial Forms', 'typography-stylist'),
+                    'category' => 'positional',
+                    'description' => esc_html__('Letterforms used in the middle of a word', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'fina',
+                    'name' => esc_html__('Terminal Forms', 'typography-stylist'),
+                    'category' => 'positional',
+                    'description' => esc_html__('Letterforms used at the end of a word', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'isol',
+                    'name' => esc_html__('Isolated Forms', 'typography-stylist'),
+                    'category' => 'positional',
+                    'description' => esc_html__('Standalone letterforms not connected to adjacent characters', 'typography-stylist')
+                ),
+                // Superscript & Ordinals
+                array(
+                    'id' => 'sups',
+                    'name' => esc_html__('Superscript', 'typography-stylist'),
+                    'category' => 'super-sub',
+                    'description' => esc_html__('Raised characters for footnotes and exponents', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'subs',
+                    'name' => esc_html__('Subscript', 'typography-stylist'),
+                    'category' => 'super-sub',
+                    'description' => esc_html__('Lowered characters for chemical formulas and indices', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'ordn',
+                    'name' => esc_html__('Ordinals', 'typography-stylist'),
+                    'category' => 'super-sub',
+                    'description' => esc_html__('Ordinal indicators like 1st, 2nd, 3rd', 'typography-stylist')
+                ),
+                // Other Features
+                array(
+                    'id' => 'kern',
+                    'name' => esc_html__('Kerning', 'typography-stylist'),
+                    'category' => 'other',
+                    'description' => esc_html__('Fine-tuned letter spacing adjustments', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'locl',
+                    'name' => esc_html__('Localized Forms', 'typography-stylist'),
+                    'category' => 'other',
+                    'description' => esc_html__('Script and language-specific character variants', 'typography-stylist')
+                ),
+                array(
+                    'id' => 'rand',
+                    'name' => esc_html__('Randomize', 'typography-stylist'),
+                    'category' => 'other',
+                    'description' => esc_html__('Randomized glyph variants for handwriting and calligraphic fonts', 'typography-stylist')
                 )
             );
         }


### PR DESCRIPTION
This pull request significantly expands the OpenType feature support in the typography plugin, increasing the number of supported features from 29 to 52 and introducing five new feature categories. It also improves the user interface for managing these features, enhances localization, and fixes a bug related to removing OpenType features without affecting other inline styles.

**OpenType Feature Expansion:**

- Added 23 new OpenType features, raising the total from 29 to 52, with new categories: Numerals & Figures, Capitals & Case, Positional Forms, Superscript & Ordinals, and expanded Ligatures and Alternates. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L178-R189) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R16) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R358-R372)

**User Interface & Admin Updates:**

- Updated UI in the block editor and admin page to include new feature categories for selection and display. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R2474-R2477) [[2]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cR2132-R2135) [[3]](diffhunk://#diff-93dde6caaeaef5a63b4a867c8bed645351ac9a4899e7a23e1d2951d435e4f876L287-R292)

**Localization Improvements:**

- Added translations for all new feature names and descriptions in Spanish and French localization files. [[1]](diffhunk://#diff-4bb44e9397c121e19584fb21bd6d57806a990e34eaa6b2ee8d269a26b7444e4eR240-R447) [[2]](diffhunk://#diff-0705093c2ed9bdf25756a26fb1f321cb356b38581b585a5b5b02e42c57aec84aR240-R447)

**Bug Fixes:**

- Fixed an issue where unchecking an OpenType feature would inadvertently remove other inline properties (like font-family or font-weight) by refining the logic for unwrapping spans and only removing the wrapper when no other attributes remain. [[1]](diffhunk://#diff-0e056b3f6675fe5e5e405a7b92ff7761acf9fcfe45a7373e588cdaed0682b29cL1940-R1981) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R358-R372)

**Documentation:**

- Updated documentation (`README.md`, `CLAUDE.md`) to reflect the expanded feature set and newly supported categories. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R16) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L178-R189) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R358-R372)