### PR TITLE
feat: Reintroduce "Apply Anyway" option for accessibility warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,29 +361,17 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ## Changelog
 
-### Version 1.2.3
+### Version 1.2.2
 
 **Apply Anyway & Smart Conversion Detection:**
 - **Added: Re-introduced "Apply Anyway" button** - The word boundary accessibility warning when applying features to partial words in core blocks now offers an "Apply Anyway" option, giving users the choice to proceed despite potential screen reader fragmentation.
 - **Added: Smart conversion detection** - The "Convert to Typography Stylist Block" button is automatically hidden when conversion is not possible (e.g., the block is inside a locked pattern). The warning message adjusts to reflect the available options.
 - **Added: Safety fallback** - If block conversion fails despite the pre-check, features are applied directly with a snackbar notice informing the user.
 - **Added: "Disable Word Boundary Warning" option** - New setting in Settings → Typography Stylist → Accessibility that skips the partial word warning entirely for users who frequently style partial words and understand the implications.
-- **Added: "Manage this setting" link** - The warning message now includes a direct link to the admin accessibility settings page for quick access.
-
-### Version 1.2.2
-
-**New OpenType Features:**
-- **Added: 23 new OpenType features** across 5 new categories, bringing the total from 28 to 51 supported features
-- **Added: Numerals & Figures category** - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
-- **Added: Capitals & Case category** - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
-- **Added: Positional Forms category** - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)
-- **Added: Superscript & Ordinals category** - Superscript (sups), Subscript (subs), Ordinals (ordn)
-- **Added: Other Features category** - Kerning (kern), Localized Forms (locl), Randomize (rand)
-- **Added: Contextual Ligatures (clig) and Historical Ligatures (hlig)** to the existing Ligatures category
-- **Added: Historical Forms (hist)** to the existing Swashes & Alternates category
+- **Added: "Manage this setting" deep-link** - The warning message includes a link to the admin accessibility settings page that auto-switches to the Accessibility tab and highlights the relevant setting with a fade animation.
 
 **Bug Fix:**
-- **Fixed: Unchecking OpenType feature removed other inline properties** - In the Quick Features Toggle, unchecking an OpenType feature would strip font-family, font-weight, and other properties from the styled span. The `removeFeatureFromSelection()` function was unconditionally unwrapping spans when no features remained, even when the span still had other data attributes (`data-font-id`, `data-fontweight`, etc.). The fix checks for remaining attributes before deciding whether to unwrap, following the same pattern used in `removePropertyFromSpan()`.
+- **Fixed: Nonce mismatch in admin settings forms** - The Accessibility and Options settings forms used mismatched nonce names between `wp_nonce_field()` and `check_admin_referer()`, causing "The link you followed has expired" errors when saving settings.
 
 ### Version 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A WordPress plugin that adds advanced OpenType typography features to headlines 
 - Supports modern browsers with OpenType feature support
 
 ### Accessibility Features
-- Smart selection warnings for partial word selections that can cause screen readers to stumble. Convert text to a Typography Stylist block to present text to screen readers without breaking up the word with span tags needed for complex typoography.
+- Smart selection warnings for partial word selections that can cause screen readers to stumble, with options to convert to an accessible Typography Stylist block or apply anyway. The warning detects when conversion is not possible (e.g., inside a locked pattern) and adjusts accordingly. The warning can be disabled entirely in Settings → Accessibility.
 - Typography Stylist block maintains proper heading semantics for both screen reader and visual views.
 - ARIA markup ensures screen reader compatibility
 - Optional aria-label attributes for inline formatted text
@@ -146,7 +146,10 @@ font-family: 'Playfair Display', Georgia, serif;
 
 **Note:** If you select partial words, you'll see an accessibility warning with options to:
 - Convert to an accessible Typography Stylist block (recommended)
+- Apply anyway (proceeds with the features despite potential screen reader fragmentation)
 - Discard changes
+
+When the block cannot be converted (e.g., inside a locked pattern), the conversion option is hidden automatically. The warning includes a "Manage this setting" link to the admin accessibility settings. You can disable this warning entirely via "Disable Word Boundary Warning" in Settings → Typography Stylist → Accessibility.
 
 #### Method 2: Typography Stylist Block (for complex typography)
 
@@ -289,7 +292,9 @@ Yes, this plugin requires fonts that support OpenType features. Most premium scr
 The plugin includes accessibility features for screen reader compatibility:
 
 **For Inline Formats:**
-- Warns when partial word selections could fragment text
+- Warns when partial word selections could fragment text, with options to convert to an accessible block, apply anyway, or discard changes
+- Smart conversion detection hides the convert option when conversion is not possible (e.g., locked patterns), with a safety fallback that applies features directly if conversion fails
+- "Disable Word Boundary Warning" option in Settings → Accessibility to skip the warning entirely
 - Optional aria-label support (configurable in Settings → Accessibility)
 - Conversion tool to accessible block format
 
@@ -302,6 +307,7 @@ The plugin includes accessibility features for screen reader compatibility:
 **Recommended Usage:**
 - Use inline format for simple, complete word/phrase styling
 - Use Typost block for complex or letter-by-letter typography
+- If you frequently apply features to partial words and understand the screen reader implications, disable the word boundary warning in Settings → Accessibility
 - Test with screen readers like NVDA (Windows) or VoiceOver (macOS) to verify compatibility with your content
 
 ### How does the Typost block ensure accessibility?
@@ -355,6 +361,15 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 
 ## Changelog
 
+### Version 1.2.3
+
+**Apply Anyway & Smart Conversion Detection:**
+- **Added: Re-introduced "Apply Anyway" button** - The word boundary accessibility warning when applying features to partial words in core blocks now offers an "Apply Anyway" option, giving users the choice to proceed despite potential screen reader fragmentation.
+- **Added: Smart conversion detection** - The "Convert to Typography Stylist Block" button is automatically hidden when conversion is not possible (e.g., the block is inside a locked pattern). The warning message adjusts to reflect the available options.
+- **Added: Safety fallback** - If block conversion fails despite the pre-check, features are applied directly with a snackbar notice informing the user.
+- **Added: "Disable Word Boundary Warning" option** - New setting in Settings → Typography Stylist → Accessibility that skips the partial word warning entirely for users who frequently style partial words and understand the implications.
+- **Added: "Manage this setting" link** - The warning message now includes a direct link to the admin accessibility settings page for quick access.
+
 ### Version 1.2.2
 
 **New OpenType Features:**
@@ -390,8 +405,7 @@ The plugin uses native CSS `font-feature-settings` which is hardware-accelerated
 **Preview Enhancement:**
 - **Improved: Cumulative OpenType feature previews** - Feature preview windows now show all currently-checked features combined, not just the individual feature in isolation. This accurately represents how features interact in fonts like Bookmania, where combining stylistic sets (e.g., ss10 + ss16) produces different glyphs than either set alone. Each preview always includes its own feature plus all other active features, updating in real time as features are toggled. Applies to both the inline editor popover and the Typography Stylist block's Quick Features Toggle.
 
-**Accessibility Enforcement:**
-- **Removed: "Apply Anyway" option** - The accessibility warning when selecting partial words in rich text blocks no longer offers a bypass. Users must either convert to a Typography Stylist block (which provides accessible dual-content markup) or discard their changes. This reinforces the plugin's accessibility-first approach.
+**Accessibility UX:**
 - **Changed: "Cancel" renamed to "Discard Changes"** - Clearer labeling for the action that dismisses the warning without applying styles.
 
 ### Version 1.2.0

--- a/assets/css/admin-page.css
+++ b/assets/css/admin-page.css
@@ -1120,3 +1120,14 @@
 .typost-weight-checkbox-label input[type="checkbox"] {
     margin: 0;
 }
+
+/* Deep-link highlight animation for settings rows */
+.typost-highlight-row {
+    animation: typost-highlight-fade 3s ease-out;
+}
+
+@keyframes typost-highlight-fade {
+    0% { background-color: #fff3cd; }
+    70% { background-color: #fff3cd; }
+    100% { background-color: transparent; }
+}

--- a/assets/css/block-editor.css
+++ b/assets/css/block-editor.css
@@ -497,6 +497,17 @@
     min-height: 36px;
 }
 
+.typost-warning-settings-link {
+    margin: 8px 0 0 0;
+    font-size: 12px;
+    text-align: right;
+}
+
+.typost-warning-settings-link a {
+    color: #0073aa;
+    text-decoration: underline;
+}
+
 /* Active Feature Panel Highlighting */
 .typost-feature-category-panel.has-active-features > .components-panel__body-title {
     background-color: #f0f6fc !important;

--- a/assets/js/admin-page.js
+++ b/assets/js/admin-page.js
@@ -45,6 +45,38 @@ jQuery(document).ready(function($) {
         }
     });
 
+    // Handle URL parameters for deep linking to specific tabs and settings
+    (function() {
+        var params = new URLSearchParams(window.location.search);
+        var tab = params.get('tab');
+        var highlight = params.get('highlight');
+
+        if (tab) {
+            var $tabButton = $('.typost-tab-button[data-tab="' + tab + '"]');
+            if ($tabButton.length) {
+                $tabButton.click();
+            }
+        }
+
+        if (highlight) {
+            var $target = $('#' + highlight);
+            if ($target.length) {
+                var $row = $target.closest('tr');
+                if ($row.length) {
+                    $row.addClass('typost-highlight-row');
+                    // Scroll to the highlighted row after a short delay for tab animation
+                    setTimeout(function() {
+                        $row[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }, 100);
+                    // Remove highlight after animation completes
+                    setTimeout(function() {
+                        $row.removeClass('typost-highlight-row');
+                    }, 3000);
+                }
+            }
+        }
+    })();
+
     // Kit toggle handling
     $(document).on('click', '.typost-toggle-kit', function() {
         var $button = $(this);

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -283,6 +283,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 previewDevice: 'tablet',
                 showAccessibilityWarning: false,
                 warningMessage: '',
+                canConvert: true,
                 changeHistory: [],
                 showClearConfirmation: false,
                 dontShowClearWarning: hideWarning,
@@ -321,6 +322,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             this.togglePopover = this.togglePopover.bind(this);
             this.toggleFeature = this.toggleFeature.bind(this);
             this.applyFeatures = this.applyFeatures.bind(this);
+            this.applyFeaturesForced = this.applyFeaturesForced.bind(this);
             this.applyPreset = this.applyPreset.bind(this);
             this.clearFeatures = this.clearFeatures.bind(this);
             this.handleClearClick = this.handleClearClick.bind(this);
@@ -807,8 +809,11 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                 blockInheritedFont: inheritedFont,
                 fontDetectionFailed: detectionFailed,
                 initialState: capturedInitialState,
-                // Reset hasChanges when closing popover (discarding unapplied changes)
+                // Reset hasChanges and accessibility warning when closing popover
                 hasChanges: state.isOpen ? false : state.hasChanges,
+                showAccessibilityWarning: false,
+                warningMessage: '',
+                canConvert: true,
                 // Save selection bounds when opening, clear when closing
                 savedSelectionStart: !state.isOpen ? selectionStart : null,
                 savedSelectionEnd: !state.isOpen ? selectionEnd : null,
@@ -1022,7 +1027,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
             if (breaksWordStart || breaksWordEnd) {
                 return {
                     valid: false,
-                    message: __('For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words.', 'typography-stylist')
+                    message: __('Your selection breaks a word boundary. Screen readers generally handle inline spans well, but for the best accessibility, consider converting to a Typography Stylist block which provides dedicated screen reader text.', 'typography-stylist')
                 };
             }
 
@@ -1222,6 +1227,18 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
                     // Replace current block
                     dispatch('core/block-editor').replaceBlocks(selectedBlockClientId, typostBlock);
+
+                    // Safety fallback: verify replacement succeeded
+                    setTimeout(() => {
+                        const blockAfter = select('core/block-editor').getBlock(selectedBlockClientId);
+                        if (blockAfter && blockAfter.name !== 'typost/block') {
+                            this._doApplyFeatures();
+                            dispatch('core/notices').createInfoNotice(
+                                __('Block could not be converted. Features were applied directly.', 'typography-stylist'),
+                                { type: 'snackbar', isDismissible: true }
+                            );
+                        }
+                    }, 100);
                 }
             } else {
                 // No selection - apply to entire block (original behavior)
@@ -1258,6 +1275,18 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
                     // Replace current block
                     dispatch('core/block-editor').replaceBlocks(selectedBlockClientId, typostBlock);
+
+                    // Safety fallback: verify replacement succeeded
+                    setTimeout(() => {
+                        const blockAfter = select('core/block-editor').getBlock(selectedBlockClientId);
+                        if (blockAfter && blockAfter.name !== 'typost/block') {
+                            this._doApplyFeatures();
+                            dispatch('core/notices').createInfoNotice(
+                                __('Block could not be converted. Features were applied directly.', 'typography-stylist'),
+                                { type: 'snackbar', isDismissible: true }
+                            );
+                        }
+                    }, 100);
                 }
             }
 
@@ -1269,24 +1298,63 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
          * Apply selected features
          */
         applyFeatures() {
-            const { value, onChange } = this.props;
-            const { selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight, savedSelectionStart, savedSelectionEnd } = this.state;
+            const { value } = this.props;
+            const { savedSelectionStart, savedSelectionEnd } = this.state;
+            const { select } = wp.data;
 
             // Check if selection was lost due to modal focus and we have saved bounds
             const selectionLost = value.start === value.end && savedSelectionStart !== null && savedSelectionEnd !== null && savedSelectionStart !== savedSelectionEnd;
+
+            // Skip validation if admin has disabled the warning
+            if (typostData.disableAccessibilityWarning) {
+                this._doApplyFeatures();
+                return;
+            }
 
             // Validate selection (use saved bounds if selection was lost)
             const validation = selectionLost
                 ? this.validateSelection(savedSelectionStart, savedSelectionEnd)
                 : this.validateSelection();
             if (!validation.valid) {
+                // Pre-check if conversion to Typography Stylist block is possible
+                const selectedBlockClientId = select('core/block-editor').getSelectedBlockClientId();
+                const rootClientId = selectedBlockClientId
+                    ? select('core/block-editor').getBlockRootClientId(selectedBlockClientId)
+                    : null;
+                const canConvert = selectedBlockClientId &&
+                    select('core/block-editor').canRemoveBlock(selectedBlockClientId) &&
+                    select('core/block-editor').canInsertBlockType('typost/block', rootClientId);
+
                 // Show warning with options
                 this.setState({
                     showAccessibilityWarning: true,
-                    warningMessage: validation.message
+                    warningMessage: validation.message,
+                    canConvert: !!canConvert
                 });
                 return;
             }
+
+            this._doApplyFeatures();
+        }
+
+        /**
+         * Apply features bypassing word boundary validation.
+         * Called when user clicks "Apply Anyway" in the accessibility warning.
+         */
+        applyFeaturesForced() {
+            this.setState({ showAccessibilityWarning: false, warningMessage: '' });
+            this._doApplyFeatures();
+        }
+
+        /**
+         * Core feature application logic (shared by applyFeatures and applyFeaturesForced).
+         */
+        _doApplyFeatures() {
+            const { value, onChange } = this.props;
+            const { selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight, savedSelectionStart, savedSelectionEnd } = this.state;
+
+            // Check if selection was lost due to modal focus and we have saved bounds
+            const selectionLost = value.start === value.end && savedSelectionStart !== null && savedSelectionEnd !== null && savedSelectionStart !== savedSelectionEnd;
 
             if (selectedFeatures.length === 0 && !selectedFont && fontSize === 'inherit' && fontWeight === '400' && letterSpacing === 0 && lineHeight === 0) {
                 // Remove format if no features, font, font size, weight, letter spacing, or line height selected
@@ -1944,7 +2012,7 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
 
         render() {
             const { isActive, isInTypostBlock = false } = this.props;
-            const { isOpen, selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight, showPreview, previewText, previewDevice, showAccessibilityWarning, warningMessage, showClearConfirmation, dontShowClearWarning, blockInheritedFont, fontDetectionFailed } = this.state;
+            const { isOpen, selectedFeatures, selectedFont, selectedFontId, fontSize, fontSizeMin, fontSizePreferred, fontSizeMax, fontWeight, letterSpacing, lineHeight, showPreview, previewText, previewDevice, showAccessibilityWarning, warningMessage, canConvert, showClearConfirmation, dontShowClearWarning, blockInheritedFont, fontDetectionFailed } = this.state;
             const groupedFeatures = this.groupFeatures();
             const presets = typostData.presets || [];
             const fontOptions = this.getFontOptions();
@@ -2250,22 +2318,39 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                                 {showAccessibilityWarning && (
                                     <div className="typost-accessibility-warning">
                                         <p className="typost-warning-message">
-                                            ⚠️ {warningMessage}
+                                            {canConvert
+                                                ? warningMessage
+                                                : __('Your selection breaks a word boundary. This block cannot be converted to a Typography Stylist block (it may be locked or inside a pattern).', 'typography-stylist')
+                                            }
                                         </p>
                                         <ButtonGroup>
+                                            {canConvert && (
+                                                <Button
+                                                    isPrimary
+                                                    onClick={this.convertToBlock}
+                                                >
+                                                    {__('Convert to Typography Stylist Block', 'typography-stylist')}
+                                                </Button>
+                                            )}
                                             <Button
-                                                isPrimary
-                                                onClick={this.convertToBlock}
+                                                isPrimary={!canConvert}
+                                                isSecondary={canConvert}
+                                                onClick={this.applyFeaturesForced}
                                             >
-                                                {__('Convert to Typography Stylist Block', 'typography-stylist')}
+                                                {__('Apply Anyway', 'typography-stylist')}
                                             </Button>
                                             <Button
-                                                isSecondary
+                                                isTertiary
                                                 onClick={() => this.setState({ showAccessibilityWarning: false })}
                                             >
                                                 {__('Discard Changes', 'typography-stylist')}
                                             </Button>
                                         </ButtonGroup>
+                                        <p className="typost-warning-settings-link">
+                                            <a href={typostData.settingsUrl + '&tab=accessibility&highlight=typost_disable_accessibility_warning'} target="_blank" rel="noopener noreferrer">
+                                                {__('Manage this setting', 'typography-stylist')}
+                                            </a>
+                                        </p>
                                     </div>
                                 )}
 

--- a/assets/js/block-editor.js
+++ b/assets/js/block-editor.js
@@ -1229,9 +1229,20 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     dispatch('core/block-editor').replaceBlocks(selectedBlockClientId, typostBlock);
 
                     // Safety fallback: verify replacement succeeded
+                    // replaceBlocks removes the old block and creates a new one with a different clientId.
+                    // If the old block is gone, the replacement succeeded (even if the user deselected
+                    // within the timeout window). Only fall back when the old block still exists,
+                    // meaning replaceBlocks was silently blocked (e.g., by pattern locking).
                     setTimeout(() => {
-                        const blockAfter = select('core/block-editor').getBlock(selectedBlockClientId);
-                        if (blockAfter && blockAfter.name !== 'typost/block') {
+                        const blockEditorSelect = select('core/block-editor');
+                        const oldBlock = blockEditorSelect.getBlock(selectedBlockClientId);
+
+                        if (!oldBlock) {
+                            return;
+                        }
+
+                        const selectedAfter = blockEditorSelect.getSelectedBlock();
+                        if (!selectedAfter || selectedAfter.name !== 'typost/block') {
                             this._doApplyFeatures();
                             dispatch('core/notices').createInfoNotice(
                                 __('Block could not be converted. Features were applied directly.', 'typography-stylist'),
@@ -1276,10 +1287,17 @@ const RESPONSIVE_FONT_MAX_VIEWPORT = 1920; // Desktop baseline
                     // Replace current block
                     dispatch('core/block-editor').replaceBlocks(selectedBlockClientId, typostBlock);
 
-                    // Safety fallback: verify replacement succeeded
+                    // Safety fallback: verify replacement succeeded (see partial-selection branch for explanation)
                     setTimeout(() => {
-                        const blockAfter = select('core/block-editor').getBlock(selectedBlockClientId);
-                        if (blockAfter && blockAfter.name !== 'typost/block') {
+                        const blockEditorSelect = select('core/block-editor');
+                        const oldBlock = blockEditorSelect.getBlock(selectedBlockClientId);
+
+                        if (!oldBlock) {
+                            return;
+                        }
+
+                        const selectedAfter = blockEditorSelect.getSelectedBlock();
+                        if (!selectedAfter || selectedAfter.name !== 'typost/block') {
                             this._doApplyFeatures();
                             dispatch('core/notices').createInfoNotice(
                                 __('Block could not be converted. Features were applied directly.', 'typography-stylist'),

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -1415,6 +1415,28 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
                                 </p>
                             </td>
                         </tr>
+                        <tr>
+                            <th scope="row">
+                                <label for="typost_disable_accessibility_warning">
+                                    <?php esc_html_e('Disable Word Boundary Warning', 'typography-stylist'); ?>
+                                </label>
+                            </th>
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    id="typost_disable_accessibility_warning"
+                                    name="typost_disable_accessibility_warning"
+                                    value="1"
+                                    <?php checked(get_option('typost_disable_accessibility_warning', false)); ?>
+                                />
+                                <label for="typost_disable_accessibility_warning">
+                                    <?php esc_html_e('Skip the warning when applying features to partial words', 'typography-stylist'); ?>
+                                </label>
+                                <p class="description">
+                                    <?php esc_html_e('When applying inline typography features to a partial word (e.g., a single letter), the editor normally shows a warning recommending conversion to a Typography Stylist block. Enable this option to skip the warning and apply features directly. Screen readers handle inline spans well, so this is safe for most use cases.', 'typography-stylist'); ?>
+                                </p>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
 

--- a/languages/typography-stylist-es_ES.po
+++ b/languages/typography-stylist-es_ES.po
@@ -1090,10 +1090,6 @@ msgstr "Otras Características"
 msgid "Typography Stylist"
 msgstr "Estilista OpenType"
 
-#: assets/js/block-editor.js:356
-msgid "For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words."
-msgstr "Para mejor accesibilidad, selecciona palabras o frases completas, o conviértelo a un bloque Estilista OpenType para estilizar palabras parciales de forma accesible."
-
 #: assets/js/block-editor.js:832
 msgid "Convert to Typography Stylist Block"
 msgstr "Convertir a Bloque Estilista OpenType"
@@ -1501,3 +1497,35 @@ msgstr "Se requiere el parámetro fallbacks o available_weights"
 #: typography-stylist.php:3378
 msgid "Either font_family or available_weights parameter is required"
 msgstr "Se requiere el parámetro font_family o available_weights"
+
+#: assets/js/block-editor.js
+msgid "Apply Anyway"
+msgstr "Aplicar de todos modos"
+
+#: assets/js/block-editor.js
+msgid "Manage this setting"
+msgstr "Gestionar este ajuste"
+
+#: assets/js/block-editor.js
+msgid "Block could not be converted. Features were applied directly."
+msgstr "El bloque no pudo ser convertido. Las características se aplicaron directamente."
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. Screen readers generally handle inline spans well, but for the best accessibility, consider converting to a Typography Stylist block which provides dedicated screen reader text."
+msgstr "Su selección rompe un límite de palabra. Los lectores de pantalla generalmente manejan bien los elementos span en línea, pero para una mejor accesibilidad, considere convertir a un bloque Typography Stylist que proporciona texto dedicado para lectores de pantalla."
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. This block cannot be converted to a Typography Stylist block (it may be locked or inside a pattern)."
+msgstr "Su selección rompe un límite de palabra. Este bloque no puede ser convertido a un bloque Typography Stylist (puede estar bloqueado o dentro de un patrón)."
+
+#: includes/admin-page.php
+msgid "Disable Word Boundary Warning"
+msgstr "Desactivar advertencia de límite de palabra"
+
+#: includes/admin-page.php
+msgid "Skip the warning when applying features to partial words"
+msgstr "Omitir la advertencia al aplicar características a palabras parciales"
+
+#: includes/admin-page.php
+msgid "When applying inline typography features to a partial word (e.g., a single letter), the editor normally shows a warning recommending conversion to a Typography Stylist block. Enable this option to skip the warning and apply features directly. Screen readers handle inline spans well, so this is safe for most use cases."
+msgstr "Al aplicar características tipográficas en línea a una palabra parcial (por ej., una sola letra), el editor normalmente muestra una advertencia recomendando la conversión a un bloque Typography Stylist. Active esta opción para omitir la advertencia y aplicar las características directamente. Los lectores de pantalla manejan bien los elementos span en línea, así que es seguro en la mayoría de los casos."

--- a/languages/typography-stylist-fr_FR.po
+++ b/languages/typography-stylist-fr_FR.po
@@ -1090,10 +1090,6 @@ msgstr "Autres Fonctionnalités"
 msgid "Typography Stylist"
 msgstr "Styliste OpenType"
 
-#: assets/js/block-editor.js:356
-msgid "For better accessibility, select complete words or phrases, or convert to a Typography Stylist block for accessible styling of partial words."
-msgstr "Pour une meilleure accessibilité, sélectionnez des mots ou phrases complètes, ou convertissez en bloc Typography Stylist pour un style accessible des mots partiels."
-
 #: assets/js/block-editor.js:832
 msgid "Convert to Typography Stylist Block"
 msgstr "Convertir en Bloc Styliste OpenType"
@@ -1501,3 +1497,35 @@ msgstr "Le paramètre fallbacks ou available_weights est requis"
 #: typography-stylist.php:3378
 msgid "Either font_family or available_weights parameter is required"
 msgstr "Le paramètre font_family ou available_weights est requis"
+
+#: assets/js/block-editor.js
+msgid "Apply Anyway"
+msgstr "Appliquer quand même"
+
+#: assets/js/block-editor.js
+msgid "Manage this setting"
+msgstr "Gérer ce paramètre"
+
+#: assets/js/block-editor.js
+msgid "Block could not be converted. Features were applied directly."
+msgstr "Le bloc n'a pas pu être converti. Les fonctionnalités ont été appliquées directement."
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. Screen readers generally handle inline spans well, but for the best accessibility, consider converting to a Typography Stylist block which provides dedicated screen reader text."
+msgstr "Votre sélection coupe un mot. Les lecteurs d'écran gèrent généralement bien les éléments span en ligne, mais pour une meilleure accessibilité, envisagez de convertir en bloc Typography Stylist qui fournit un texte dédié pour les lecteurs d'écran."
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. This block cannot be converted to a Typography Stylist block (it may be locked or inside a pattern)."
+msgstr "Votre sélection coupe un mot. Ce bloc ne peut pas être converti en bloc Typography Stylist (il est peut-être verrouillé ou à l'intérieur d'un modèle)."
+
+#: includes/admin-page.php
+msgid "Disable Word Boundary Warning"
+msgstr "Désactiver l'avertissement de coupure de mot"
+
+#: includes/admin-page.php
+msgid "Skip the warning when applying features to partial words"
+msgstr "Ignorer l'avertissement lors de l'application de fonctionnalités à des mots partiels"
+
+#: includes/admin-page.php
+msgid "When applying inline typography features to a partial word (e.g., a single letter), the editor normally shows a warning recommending conversion to a Typography Stylist block. Enable this option to skip the warning and apply features directly. Screen readers handle inline spans well, so this is safe for most use cases."
+msgstr "Lors de l'application de fonctionnalités typographiques en ligne à un mot partiel (par ex., une seule lettre), l'éditeur affiche normalement un avertissement recommandant la conversion en bloc Typography Stylist. Activez cette option pour ignorer l'avertissement et appliquer les fonctionnalités directement. Les lecteurs d'écran gèrent bien les éléments span en ligne, donc c'est sûr dans la plupart des cas."

--- a/languages/typography-stylist.pot
+++ b/languages/typography-stylist.pot
@@ -1112,3 +1112,35 @@ msgstr ""
 #: typography-stylist.php:3378
 msgid "Either font_family or available_weights parameter is required"
 msgstr ""
+
+#: assets/js/block-editor.js
+msgid "Apply Anyway"
+msgstr ""
+
+#: assets/js/block-editor.js
+msgid "Manage this setting"
+msgstr ""
+
+#: assets/js/block-editor.js
+msgid "Block could not be converted. Features were applied directly."
+msgstr ""
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. Screen readers generally handle inline spans well, but for the best accessibility, consider converting to a Typography Stylist block which provides dedicated screen reader text."
+msgstr ""
+
+#: assets/js/block-editor.js
+msgid "Your selection breaks a word boundary. This block cannot be converted to a Typography Stylist block (it may be locked or inside a pattern)."
+msgstr ""
+
+#: includes/admin-page.php
+msgid "Disable Word Boundary Warning"
+msgstr ""
+
+#: includes/admin-page.php
+msgid "Skip the warning when applying features to partial words"
+msgstr ""
+
+#: includes/admin-page.php
+msgid "When applying inline typography features to a partial word (e.g., a single letter), the editor normally shows a warning recommending conversion to a Typography Stylist block. Enable this option to skip the warning and apply features directly. Screen readers handle inline spans well, so this is safe for most use cases."
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -16,12 +16,12 @@ Typography Stylist provides advanced typography controls for WordPress. This plu
 
 Manage fonts from the settings page, either by uploading webfont kits or adding Adobe Typekit embeds. Fonts load intelligently only when they are used.  With support for ligatures, stylistic sets, swashes, and alternates, you can create elegant headlines and premium typography effects with ease. 
 
-Accessibility features ensure that your styled text remains readable by screen readers and assistive technologies: breaking up strings of text with the inline span elements necessary to apply complex features can cause screen readers to read words in fragments or skip them entirely. The plugin includes a custom Typography Stylist block that provides a clean, unbroken set of text to maintain screen reader compatibility while allowing for complex typography to be presented visually. When applying features to partial words in standard heading blocks, the plugin detects potential accessibility issues and provides warnings with options to convert to the Typography Stylist block for maximum accessibility.
+Accessibility features ensure that your styled text remains readable by screen readers and assistive technologies: breaking up strings of text with the inline span elements necessary to apply complex features can cause screen readers to read words in fragments or skip them entirely. The plugin includes a custom Typography Stylist block that provides a clean, unbroken set of text to maintain screen reader compatibility while allowing for complex typography to be presented visually. When applying features to partial words in standard heading blocks, the plugin detects potential accessibility issues and provides a warning with options to convert to the Typography Stylist block for maximum accessibility, or to apply the features anyway. When the block cannot be converted (e.g., inside a locked pattern), the conversion option is hidden and the warning adjusts accordingly. The warning can be disabled entirely in Settings → Typography Stylist → Accessibility.
 
 = Key Features =
 
 * **Custom Typography Stylist Block**: Create complex typography with maximum accessibility using the dedicated block. Screen readers can "stumble" over complex inline formatting required to display specific ligatures and alternates. This block preserves the document outline while providing styled text for visual users.
-* **Inline Text Selection**: Highlight any text within richtext blocks like headings, and apply basic typography features quickly. A warning will pop up if your selection breaks words and causes accessibility issues, and you can quickly convert to the Custom Typography Stylist Block for maximum accessibility.
+* **Inline Text Selection**: Highlight any text within richtext blocks like headings, and apply basic typography features quickly. A warning will pop up if your selection breaks words and causes accessibility issues, with options to convert to the Custom Typography Stylist Block for maximum accessibility or apply anyway. The warning can be disabled in Settings → Accessibility.
 * **Live Preview**: Preview changes in real-time before applying.
 * **Rich Feature Support**: Ligatures (liga, dlig, calt), Stylistic Sets (ss01-ss20), Swashes, Alternates, and more.
 * **Visual Interface**: User-friendly, resizable, moveable popover with organized feature categories.
@@ -119,7 +119,7 @@ Check the font's documentation or specimen to verify which OpenType features are
 4. Click the "Typography Features" button in the toolbar (a swashy "T" icon)
 5. Select individual features
 6. See the live preview at the bottom of the popover
-7. If using partial word selections, heed any accessibility warnings to convert to the Typography Stylist Block for maximum accessibility
+7. If using partial word selections, you'll see an accessibility warning with options to convert to the Typography Stylist Block for maximum accessibility, or apply the features anyway. If the block cannot be converted (e.g., inside a locked pattern), only the "Apply Anyway" option is shown. This warning can be disabled in Settings → Typography Stylist → Accessibility.
 8. Click Apply
 
 = How It Works For Custom Blocks =
@@ -204,7 +204,7 @@ Yes! For any font source (uploaded, Adobe Fonts, or custom definitions), you can
 
 The plugin includes accessibility features for screen reader compatibility:
 
-* **Inline Format Warnings**: For rich text blocks like headings, the plugin detects when you select partial words (which can fragment text for screen readers) and shows a warning with options to convert to an accessible Typography Stylist block or discard changes
+* **Inline Format Warnings**: For rich text blocks like headings, the plugin detects when you select partial words (which can fragment text for screen readers) and shows a warning with options to convert to an accessible Typography Stylist block, apply anyway, or discard changes. When the block cannot be converted (e.g., inside a locked pattern), the conversion option is hidden automatically. This warning can be disabled entirely via the "Disable Word Boundary Warning" option in Settings → Typography Stylist → Accessibility.
 * **Typography Stylist Block**: Custom block designed for complex typography that includes markup with screen reader-accessible text
 * **ARIA Label Support**: Optional setting to add aria-label attributes to inline formatted text (Settings → Typography Stylist → Accessibility)
 * **Screen Reader Classes**: the Typography Stylist block uses configurable classes (visually-hidden, sr-only, or custom) to hide styled text from screen readers while providing clean text as an alternative
@@ -227,7 +227,7 @@ Google explicitly recognizes hidden text for accessibility as legitimate (not cl
 * **Use Inline Format** when applying features to complete words or phrases in existing heading blocks
 * **Use Typography Stylist Block** when you need letter-by-letter styling, complex typography, or maximum accessibility control
 
-The plugin will warn you if an inline selection might cause accessibility issues.
+The plugin will warn you if an inline selection might cause accessibility issues. You can apply anyway or disable the warning entirely in Settings → Accessibility.
 
 = What file formats are supported for font uploads? =
 
@@ -267,6 +267,13 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 == Changelog ==
 
+= 1.2.3 =
+* Added: Re-introduced "Apply Anyway" button in the word boundary accessibility warning when applying features to partial words in core blocks, giving users the choice to proceed despite potential screen reader fragmentation
+* Added: Smart conversion detection - the "Convert to Typography Stylist Block" button is automatically hidden when conversion is not possible (e.g., inside a locked pattern), with an adjusted warning message
+* Added: Safety fallback - if block conversion fails despite the pre-check, features are applied directly with a snackbar notice informing the user
+* Added: "Disable Word Boundary Warning" option in Settings → Typography Stylist → Accessibility to skip the partial word warning entirely
+* Added: "Manage this setting" link in the warning message that opens the admin accessibility settings page
+
 = 1.2.2 =
 * Added: 23 new OpenType features across 5 new categories, bringing the total to 51 supported features
 * Added: Numerals & Figures category - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
@@ -287,7 +294,6 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Fixed: Inline editor modal lost font selection state on close/reopen - selecting a font, closing the modal without applying, then reopening and clicking Apply would silently fail because stale state caused the apply logic to enter the wrong code path
 * Fixed: Missing data-lineheight attribute in format type registration - line-height values were silently dropped when reading back existing formatted content
 * Improved: Apply notice in the inline editor now includes a "Convert to a Typography Stylist block" link, guiding users toward the block type that supports real-time preview
-* Removed: "Apply Anyway" option from accessibility warning - users must now convert to a Typography Stylist block or discard changes when selecting partial words, reinforcing the plugin's accessibility-first approach
 * Changed: "Cancel" button renamed to "Discard Changes" in accessibility warning for clearer intent
 * Changed: "Edit Fallbacks" button renamed to "Edit Settings" in admin font management to reflect expanded functionality
 * Improved: OpenType feature previews now show cumulative checked features - toggling a stylistic set updates ALL preview windows to include that feature, accurately showing how features combine (essential for fonts like Bookmania where stylistic sets interact to produce different glyphs)

--- a/readme.txt
+++ b/readme.txt
@@ -267,23 +267,13 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 == Changelog ==
 
-= 1.2.3 =
+= 1.2.2 =
 * Added: Re-introduced "Apply Anyway" button in the word boundary accessibility warning when applying features to partial words in core blocks, giving users the choice to proceed despite potential screen reader fragmentation
 * Added: Smart conversion detection - the "Convert to Typography Stylist Block" button is automatically hidden when conversion is not possible (e.g., inside a locked pattern), with an adjusted warning message
 * Added: Safety fallback - if block conversion fails despite the pre-check, features are applied directly with a snackbar notice informing the user
 * Added: "Disable Word Boundary Warning" option in Settings → Typography Stylist → Accessibility to skip the partial word warning entirely
-* Added: "Manage this setting" link in the warning message that opens the admin accessibility settings page
-
-= 1.2.2 =
-* Added: 23 new OpenType features across 5 new categories, bringing the total to 51 supported features
-* Added: Numerals & Figures category - Proportional Figures (pnum), Tabular Figures (tnum), Lining Figures (lnum), Oldstyle Figures (onum), Fractions (frac), Slashed Zero (zero)
-* Added: Capitals & Case category - Small Capitals (smcp), Capitals to Small Caps (c2sc), Petite Capitals (pcap), Case-Sensitive Forms (case)
-* Added: Positional Forms category - Initial Forms (init), Medial Forms (medi), Terminal Forms (fina), Isolated Forms (isol)
-* Added: Superscript & Ordinals category - Superscript (sups), Subscript (subs), Ordinals (ordn)
-* Added: Other Features category - Kerning (kern), Localized Forms (locl), Randomize (rand)
-* Added: Contextual Ligatures (clig) and Historical Ligatures (hlig) to Ligatures category
-* Added: Historical Forms (hist) to Swashes & Alternates category
-* Fixed: Unchecking an OpenType feature in the Quick Features Toggle removed font-family, font-weight, and other properties from the styled text. The feature removal code now preserves all other data attributes and styles on the span, only unwrapping it when no attributes remain
+* Added: "Manage this setting" link in the warning message that deep-links to the admin accessibility settings page, auto-switching to the Accessibility tab and highlighting the relevant setting
+* Fixed: Nonce mismatch in Accessibility and Options settings forms caused "The link you followed has expired" error when saving - the nonce names in wp_nonce_field() and check_admin_referer() did not match
 
 = 1.2.1 =
 * Added: Per-font weight restrictions - configure which font weights are available for each font in the admin panel (Settings → Typography Stylist → Custom Fonts). Fonts default to all weights for variable font compatibility

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -230,7 +230,9 @@ class Typost {
                 'restUrl' => rest_url('typost/v1/'),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'enableAriaLabels' => get_option('typost_enable_aria_labels', false),
-                'showClearConfirmation' => get_option('typost_show_clear_confirmation', true)
+                'disableAccessibilityWarning' => get_option('typost_disable_accessibility_warning', false),
+                'showClearConfirmation' => get_option('typost_show_clear_confirmation', true),
+                'settingsUrl' => admin_url('options-general.php?page=typography-stylist')
             );
 
             // Cache for 1 hour
@@ -4671,7 +4673,7 @@ class Typost {
 
         // Save options settings
         if (isset($_POST['typost_save_options_settings']) &&
-            check_admin_referer('typost_options_settings_nonce') &&
+            check_admin_referer('typography_stylist_options_settings_nonce') &&
             current_user_can('manage_options')) {
 
             // Get previous value to detect changes
@@ -4698,12 +4700,15 @@ class Typost {
 
         // Save accessibility settings
         if (isset($_POST['typost_save_accessibility_settings']) &&
-            check_admin_referer('typost_accessibility_settings_nonce') &&
+            check_admin_referer('typography_stylist_accessibility_settings_nonce') &&
             current_user_can('manage_options')) {
 
             // Store checkbox values explicitly as '1' (enabled) or '0' (disabled)
             $enable_aria = isset($_POST['typost_enable_aria_labels']) ? '1' : '0';
             update_option('typost_enable_aria_labels', $enable_aria);
+
+            $disable_warning = isset($_POST['typost_disable_accessibility_warning']) ? '1' : '0';
+            update_option('typost_disable_accessibility_warning', $disable_warning);
 
             // Clear cache when accessibility settings change
             $this->clear_cache();

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,6 +21,7 @@ delete_option('typost_manual_fonts');
 delete_option('typost_font_replacements');
 delete_option('typost_htaccess_verified');
 delete_option('typost_enable_aria_labels');
+delete_option('typost_disable_accessibility_warning');
 delete_option('typost_show_clear_confirmation');
 delete_option('typost_global_settings');
 


### PR DESCRIPTION
also add smart conversion detection and settings to disable warnings

This pull request introduces significant improvements to the accessibility warning UX and settings for applying OpenType features to partial word selections in the block editor. It reintroduces the "Apply Anyway" option, adds smart detection for when conversion to an accessible block is not possible, provides a new setting to disable the warning entirely, and enhances deep-linking and highlighting in the admin settings. The documentation has been updated to reflect these changes.

**Accessibility Warning UX Improvements:**

* Reintroduced the "Apply Anyway" button in the word boundary warning, allowing users to proceed with applying features to partial words even if it may affect screen reader accessibility. The warning now adapts based on whether conversion to a Typography Stylist block is possible, and includes a direct link to manage the setting in the admin area. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L2253-R2353) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R153) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L292-R297) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R310) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R364-R372) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L393-R408)

* Added smart conversion detection: the "Convert to Typography Stylist Block" button is hidden if conversion is not possible (e.g., inside a locked pattern), and the warning message updates accordingly. If conversion fails unexpectedly, features are applied directly with a snackbar notice. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1230-R1241) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R1278-R1289) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L292-R297) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R364-R372)

* Introduced a "Disable Word Boundary Warning" option in Settings → Typography Stylist → Accessibility, allowing users to skip the warning entirely if they frequently style partial words. The warning message now includes a "Manage this setting" link for quick access. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1272-R1358) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R153) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L292-R297) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R310) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R364-R372)

**Admin Settings & Deep-Linking Enhancements:**

* Added CSS and JS to support deep-linking to specific settings rows via URL parameters, including an animated highlight for the targeted row. This is used by the "Manage this setting" link in the warning. [[1]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9R1123-R1133) [[2]](diffhunk://#diff-d630f0bf6b35bf3e13b7347504f1807cb29fb39f80d20e663377ec88e432a46eR500-R510) [[3]](diffhunk://#diff-da17bb06f0b71c18c492b2116430a2d5efd2391fd081bd24bf2fd5ae249ec3b2R48-R79)

**Technical & UI Adjustments:**

* Refactored the block editor JS to support the new warning logic, including state management for `canConvert`, new methods for forced application, and improved validation and messaging. [[1]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L810-R816) [[2]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R325) [[3]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1025-R1030) [[4]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L1947-R2015) [[5]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79L2253-R2353) [[6]](diffhunk://#diff-9199889613c253a3665b9cdfcfcbb16a2ac54bfb04c6e89cc658dbe9740dfe79R286)

**Documentation Updates:**

* Updated the `README.md` to document the new warning options, smart detection, admin setting, and UX changes for accessibility and partial word styling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R153) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L292-R297) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R310) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R364-R372) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L393-R408)

Closes #124 