### PR TITLE
Make Font Feature tabs consistent with the rest of the UI

### DIFF
--- a/assets/css/admin-page.css
+++ b/assets/css/admin-page.css
@@ -204,7 +204,7 @@
     display: flex;
     align-items: center;
     padding: 15px;
-    padding-left: 36px;
+    padding-inline-start: 36px;
     gap: 10px;
     background: #f0f0f1;
     border-bottom: 1px solid #c3c4c7;
@@ -221,7 +221,7 @@
 .typost-feature-category-summary::before {
     content: '▶';
     position: absolute;
-    left: 15px;
+    inset-inline-start: 15px;
     color: #1d2327;
     transition: transform 0.2s;
     font-size: 12px;
@@ -242,11 +242,10 @@
 }
 
 /* Category name in summary */
-.typost-feature-category-summary h3 {
+.typost-feature-category-title {
     color: #1d2327;
     font-size: 16px;
     font-weight: 600;
-    margin: 0;
 }
 
 /* Feature count badge */
@@ -255,7 +254,7 @@
     font-weight: 400;
     color: #646970;
     min-width: 60px;
-    text-align: left;
+    text-align: start;
 }
 
 /* Feature Demos Grid */
@@ -489,7 +488,7 @@ details.typost-font-kit-card {
     display: flex;
     align-items: center;
     padding: 15px;
-    padding-left: 36px;
+    padding-inline-start: 36px;
     gap: 10px;
     background: #f0f0f1;
     border-bottom: 1px solid #c3c4c7;
@@ -506,7 +505,7 @@ details.typost-font-kit-card {
 .typost-font-kit-header::before {
     content: '▶';
     position: absolute;
-    left: 15px;
+    inset-inline-start: 15px;
     color: #1d2327;
     transition: transform 0.2s;
     font-size: 12px;
@@ -537,7 +536,7 @@ details.typost-font-kit-card[open] > .typost-font-kit-header::before {
     font-weight: 400;
     color: #646970;
     min-width: 60px;
-    text-align: left;
+    text-align: start;
 }
 
 .typost-kit-fonts {

--- a/assets/css/admin-page.css
+++ b/assets/css/admin-page.css
@@ -189,21 +189,26 @@
     hyphens: auto;
 }
 
-/* Feature Category Section */
+/* Feature Category Section — card style matching font kit headers */
 .typost-feature-category-section {
-    margin: 30px 0;
-    border-bottom: 1px solid #ddd;
-}
-
-.typost-feature-category-section:last-of-type {
-    border-bottom: none;
+    border: 1px solid #c3c4c7;
+    margin-bottom: 20px;
+    border-radius: 4px;
+    background: #fff;
 }
 
 /* Collapsible summary styles */
 .typost-feature-category-summary {
     cursor: pointer;
     list-style: none;
-    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    padding: 15px;
+    padding-left: 36px;
+    gap: 10px;
+    background: #f0f0f1;
+    border-bottom: 1px solid #c3c4c7;
+    position: relative;
 }
 
 /* Remove default marker/disclosure triangle */
@@ -212,55 +217,45 @@
     display: none;
 }
 
-.typost-feature-category-summary:focus {
-    outline: 2px solid #2271b1;
-    outline-offset: 8px;
-}
-
-/* Style the h3 to include the arrow */
-.typost-feature-category-section > summary > h3,
-.typost-feature-category-section > .typost-feature-category-summary > h3 {
-    color: #2271b1;
-    font-size: 18px;
-    margin: 0;
-    padding-bottom: 16px;
-    padding-left: 30px;
-    border-bottom: 2px solid #2271b1;
-    position: relative;
-    display: inline-block;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-/* Add arrow before h3 */
-.typost-feature-category-section > summary > h3::before,
-.typost-feature-category-section > .typost-feature-category-summary > h3::before {
+/* Custom arrow */
+.typost-feature-category-summary::before {
     content: '▶';
     position: absolute;
-    left: 0;
-    color: #2271b1;
+    left: 15px;
+    color: #1d2327;
     transition: transform 0.2s;
-    display: inline-block;
-    width: 20px;
+    font-size: 12px;
 }
 
-/* Rotate arrow when open */
-.typost-feature-category-section[open] > summary > h3::before,
-.typost-feature-category-section[open] > .typost-feature-category-summary > h3::before {
+.typost-feature-category-section[open] > .typost-feature-category-summary::before {
     transform: rotate(90deg);
 }
 
-.typost-feature-category-summary:hover > h3 {
-    opacity: 0.8;
+.typost-feature-category-summary:hover {
+    background: #e8e8e9;
 }
 
-/* Legacy support for non-collapsible sections */
-.typost-feature-category-section > h3 {
-    color: #2271b1;
-    font-size: 18px;
-    margin-bottom: 20px;
-    padding-bottom: 8px;
-    border-bottom: 2px solid #2271b1;
+.typost-feature-category-summary:focus {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* Category name in summary */
+.typost-feature-category-summary h3 {
+    color: #1d2327;
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+}
+
+/* Feature count badge */
+.typost-feature-category-count {
+    font-size: 13px;
+    font-weight: 400;
+    color: #646970;
+    min-width: 60px;
+    text-align: left;
 }
 
 /* Feature Demos Grid */
@@ -268,7 +263,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
     gap: 20px;
-    margin: 20px 0;
+    padding: 15px;
 }
 
 .typost-feature-demo-card {

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -318,7 +318,7 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
             <?php foreach ($grouped_features as $category => $features): ?>
             <details <?php echo $category === 'ligatures' ? 'open' : ''; ?> class="typost-feature-category-section">
                 <summary class="typost-feature-category-summary">
-                    <h3><?php echo esc_html(isset($category_titles[$category]) ? $category_titles[$category] : ucfirst($category)); ?></h3>
+                    <span class="typost-feature-category-title" role="heading" aria-level="3"><?php echo esc_html(isset($category_titles[$category]) ? $category_titles[$category] : ucfirst($category)); ?></span>
                     <span class="typost-feature-category-count"><?php
                         $count = count($features);
                         echo esc_html(sprintf(

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -319,6 +319,14 @@ function typost_render_admin_template($instance, $presets, $custom_fonts, $adobe
             <details <?php echo $category === 'ligatures' ? 'open' : ''; ?> class="typost-feature-category-section">
                 <summary class="typost-feature-category-summary">
                     <h3><?php echo esc_html(isset($category_titles[$category]) ? $category_titles[$category] : ucfirst($category)); ?></h3>
+                    <span class="typost-feature-category-count"><?php
+                        $count = count($features);
+                        echo esc_html(sprintf(
+                            /* translators: %d: number of features in category */
+                            _n('%d feature', '%d features', $count, 'typography-stylist'),
+                            $count
+                        ));
+                    ?></span>
                 </summary>
 
                 <div class="typost-feature-demos-grid">


### PR DESCRIPTION
This pull request updates the visual style and structure of the feature category sections on the admin page to improve clarity and user experience. The main changes include restyling the category sections to use a card-like appearance, updating the summary and arrow indicator, adding a feature count badge, and refining the layout of the feature demos grid.

**Feature Category Section Redesign:**

* Changed `.typost-feature-category-section` to use a card style with border, background, and rounded corners, matching the font kit headers for a more modern look.
* Updated `.typost-feature-category-summary` to use a flex layout, improved padding, and a new background, with a custom arrow indicator and hover/focus states. The arrow now appears to the left of the summary and rotates when open. [[1]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9L192-R211) [[2]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9L215-R266)
* Simplified and restyled the category name (`h3`) and added a feature count badge (`.typost-feature-category-count`) next to the category name in the summary. [[1]](diffhunk://#diff-d4f1076b9ed74a497a86d19bce60080fd7674c0dca06c9d9791950a888a9a9b9L215-R266) [[2]](diffhunk://#diff-93dde6caaeaef5a63b4a867c8bed645351ac9a4899e7a23e1d2951d435e4f876R322-R329)

**Feature Count Badge:**

* Added a feature count badge in the summary of each category, displaying the number of features in that category using proper pluralization and localization.

**Feature Demos Grid Layout:**

* Updated `.typost-feature-demos-grid` to use padding instead of margin, ensuring better alignment within the new card-style section.