### PR TITLE
Fix mixed-content blocking of locally-hosted fonts in the Glyphs Pane…

### DIFF
--- a/glyphs-panel/__tests__/font-loader.test.js
+++ b/glyphs-panel/__tests__/font-loader.test.js
@@ -6,10 +6,44 @@
 const {
 	parseSrcUrls,
 	formatFromUrl,
+	normalizeFetchUrl,
 	pickBestUrl,
 	pickFaceForWeight,
 	sniffFormat
 } = require('../assets/js/lib/font-loader.js');
+
+describe('normalizeFetchUrl', () => {
+	const httpsPage = { protocol: 'https:', host: 'mnc4.com' };
+	const httpPage = { protocol: 'http:', host: 'mnc4.com' };
+
+	test('upgrades a same-host http:// font URL to https on an HTTPS page', () => {
+		expect(normalizeFetchUrl(
+			'http://mnc4.com/bus1984/wp-content/uploads/typography-stylist/fonts/kit-1/font.woff2',
+			httpsPage
+		)).toBe('https://mnc4.com/bus1984/wp-content/uploads/typography-stylist/fonts/kit-1/font.woff2');
+	});
+
+	test('leaves a cross-origin http:// URL untouched (other origin may not serve HTTPS)', () => {
+		const url = 'http://cdn.example.com/font.woff2';
+		expect(normalizeFetchUrl(url, httpsPage)).toBe(url);
+	});
+
+	test('does not change URLs when the page is not HTTPS', () => {
+		const url = 'http://mnc4.com/font.woff2';
+		expect(normalizeFetchUrl(url, httpPage)).toBe(url);
+	});
+
+	test('leaves already-secure, protocol-relative, and root-relative URLs as-is', () => {
+		expect(normalizeFetchUrl('https://mnc4.com/font.woff2', httpsPage)).toBe('https://mnc4.com/font.woff2');
+		expect(normalizeFetchUrl('//mnc4.com/font.woff2', httpsPage)).toBe('//mnc4.com/font.woff2');
+		expect(normalizeFetchUrl('/wp-content/uploads/font.woff2', httpsPage)).toBe('/wp-content/uploads/font.woff2');
+	});
+
+	test('returns non-string and malformed input unchanged', () => {
+		expect(normalizeFetchUrl(null, httpsPage)).toBe(null);
+		expect(normalizeFetchUrl('http://', httpsPage)).toBe('http://');
+	});
+});
 
 describe('parseSrcUrls', () => {
 	test('parses a typical webfont kit @font-face block', () => {

--- a/glyphs-panel/assets/js/lib/font-loader.js
+++ b/glyphs-panel/assets/js/lib/font-loader.js
@@ -92,6 +92,39 @@
 	}
 
 	/**
+	 * Upgrade an insecure same-host font URL to HTTPS so it isn't blocked as
+	 * mixed content on an HTTPS page.
+	 *
+	 * Uploaded webfont-kit CSS can contain absolute http:// file URLs. The
+	 * rendered @font-face CSS is relativized at output time, but the Glyphs
+	 * Panel parses the raw stored CSS and fetches the file directly, so it must
+	 * upgrade the protocol itself. Only same-host URLs are upgraded — a
+	 * cross-origin http:// URL is left untouched because we can't assume the
+	 * other origin serves HTTPS (the browser blocks it as mixed content either
+	 * way, surfaced as a fetch/cors failure).
+	 *
+	 * @param {string} url      Font file URL
+	 * @param {Object} [location] Page location ({protocol, host}); defaults to window.location
+	 * @return {string} Possibly-upgraded URL
+	 */
+	function normalizeFetchUrl(url, location) {
+		var loc = location || (typeof window !== 'undefined' ? window.location : null);
+		if (typeof url !== 'string' || url.indexOf('http://') !== 0 || !loc || loc.protocol !== 'https:') {
+			return url;
+		}
+		try {
+			var parsed = new URL(url);
+			if (parsed.host === loc.host) {
+				parsed.protocol = 'https:';
+				return parsed.href;
+			}
+		} catch (e) {
+			// Malformed URL — fall through and return the original
+		}
+		return url;
+	}
+
+	/**
 	 * Pick the best parseable URL from a face's src list.
 	 * Preference: woff2 > woff > ttf > otf. EOT/unknown are excluded.
 	 *
@@ -466,6 +499,9 @@
 			if (!resolved.ok) {
 				return resolved;
 			}
+			// Upgrade same-host http:// URLs to https on secure pages so the
+			// file fetch isn't blocked as mixed content
+			resolved.url = normalizeFetchUrl(resolved.url);
 			return fetch(resolved.url, { mode: 'cors' }).then(function(response) {
 				if (!response.ok) {
 					return { ok: false, reason: 'fetch-failed' };
@@ -526,6 +562,9 @@
 			if (!resolved.ok) {
 				return resolved;
 			}
+			// Upgrade same-host http:// URLs to https on secure pages so the
+			// file fetch isn't blocked as mixed content
+			resolved.url = normalizeFetchUrl(resolved.url);
 			return fetch(resolved.url, { mode: 'cors' }).then(function(response) {
 				if (!response.ok) {
 					return { ok: false, reason: 'fetch-failed' };
@@ -564,6 +603,7 @@
 	var api = {
 		parseSrcUrls: parseSrcUrls,
 		formatFromUrl: formatFromUrl,
+		normalizeFetchUrl: normalizeFetchUrl,
 		pickBestUrl: pickBestUrl,
 		pickFaceForWeight: pickFaceForWeight,
 		sniffFormat: sniffFormat,

--- a/glyphs-panel/glyphs-panel.php
+++ b/glyphs-panel/glyphs-panel.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Guard the constants so a still-active standalone copy (deactivated but left
 // on disk) cannot trigger a duplicate define() or a fatal class redeclare.
 if ( ! defined( 'TYPOST_GP_VERSION' ) ) {
-	define( 'TYPOST_GP_VERSION', '1.1.0' );
+	define( 'TYPOST_GP_VERSION', '1.1.1' );
 	define( 'TYPOST_GP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'TYPOST_GP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matthewneilcowan
 Tags: typography, opentype, fonts, ligatures, glyphs
 Requires at least: 5.8
 Tested up to: 6.9.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -275,6 +275,9 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 
 == Changelog ==
 
+= 2.0.1 =
+* Fixed: Mixed-content blocking of locally-hosted fonts in the Glyphs Panel — same-host `http://` font file URLs are now upgraded to `https://` before fetching, so fonts whose stored kit CSS contains absolute insecure URLs load correctly on HTTPS sites (cross-origin URLs are left untouched)
+
 = 2.0.0 =
 * **NEW: Glyphs Panel (built into core) — the flagship feature of 2.0.** An Illustrator-style full-font glyph browser. Explore every character and OpenType feature in a font; search by character, U+ codepoint, or glyph name; filter by Unicode block, stylistic set, or OpenType feature; and view all alternates for a single character. Click or press Enter to insert any glyph (including indexed feature alternates) directly into your content via a "Glyphs…" button in the inline rich-text toolbar (any heading or paragraph), in the Typography Stylist block's Quick Feature Toggles, or from a dedicated "Glyphs" admin tab (browse + copy to clipboard); closing the panel returns you to the editor popover you launched it from. Accessible by design: the glyph grid is a fully keyboard-navigable ARIA grid (arrow keys, Home/End, Page Up/Down, Enter to insert) with row/column semantics, and insertions and result counts are announced to screen readers — inserted glyphs use the real Unicode character plus CSS font-feature-settings, so assistive technology always reads the underlying text. Works with uploaded webfont kits, Adobe Fonts, custom font definitions, and WordPress Font Library fonts; font files are read in your browser, on demand, for metadata only — no glyph outlines are ever extracted or stored, and nothing font-derived is written to your server, making sure you respect font EULAs.
 * **MAJOR CHANGE:** Inline text editor (richtext toolbar button) now uses live preview instead of Apply button paradigm - changes are auto-applied immediately with debouncing (matching the Typography Stylist block UX)
@@ -309,6 +312,8 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Added: REST endpoints for font feature visibility (`GET/POST /typost/v1/font-feature-visibility/{font_id}`) and font order (`GET/POST /typost/v1/font-order`)
 * Added: `filterFeaturesByVisibility()` utility function (exported from utils.js and exposed via `window.typostSharedUtils`) for filtering features based on per-font visibility settings
 * Fixed: Editor nonce was incorrectly cached in transient (nonces are session-specific and must always be fresh)
+* Fixed: Help tab section headers now use the primary text color instead of the accent color, fixing low contrast in the Alice Blue admin color scheme (WCAG-compliant across all schemes)
+* Fixed: REST API namespace in bundled documentation corrected to the canonical `/wp-json/typost/v1/`
 * Removed: Apply button from inline editor toolbar
 * Removed: "Apply Anyway" and "Discard Changes" buttons from the word boundary accessibility warning workflow — these warning-specific actions are now obsolete because the warning is non-blocking and changes apply immediately via live preview
 * Removed: Internal undo system (Undo button) - now relies on native WordPress undo (Ctrl+Z)
@@ -324,6 +329,8 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Improved: Font Features tab preview selector now includes WP Font Library fonts (when available) alongside uploaded, Adobe, and custom fonts
 * Improved: Feature visibility changes auto-save on toggle with a brief "Saved" confirmation — no Save button needed
 * Improved: Per-font feature visibility includes master "Enable All" / "Disable All" controls both on the Font Features tab and inside each font's edit form
+* Improved: Glyphs Panel toolbar controls (Alternates, Search, OpenType feature, Unicode block) now show visible labels
+* Improved: Glyphs Panel default "All glyphs" view also lists OpenType feature variants (e.g. stylistic alternates) previously reachable only by filtering or typing a character
 * Note: Each debounced change creates its own undo step in WordPress undo history - use Ctrl+Z to undo individual changes (more granular than previous single Apply button undo)
 * Note: WP Font Library fonts appear in the admin list as read-only; font order and feature visibility settings for WP Library fonts are not yet supported in this release
 
@@ -465,6 +472,9 @@ Check your font's documentation, or use the plugin to experiment. Features that 
 * Rate-limited REST API endpoints (50 requests/minute per user)
 
 == Upgrade Notice ==
+
+= 2.0.1 =
+Fixes mixed-content blocking of locally-hosted fonts in the Glyphs Panel on HTTPS sites.
 
 = 2.0.0 =
 Major release: the Glyphs Panel — a full-font glyph browser — is now built into the core plugin, available in both editors and a new Glyphs admin tab. Also adds an extensibility hook system, live preview in the inline editor, and unified font management. Existing content and settings are preserved.

--- a/typography-stylist.php
+++ b/typography-stylist.php
@@ -3,7 +3,7 @@
  * Plugin Name: Typography Stylist
  * Plugin URI: https://wordpress.org/plugins/typography-stylist/
  * Description: Add advanced OpenType features (ligatures, stylistic sets, swashes) to headlines with inline text selection and live preview.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: Matthew Cowan
  * Author URI: https://mnc4.com
  * License: GPL v2 or later
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 
 // Define plugin constants (check if already defined for test compatibility)
 if (!defined('TYPOST_VERSION')) {
-    define('TYPOST_VERSION', '2.0.0');
+    define('TYPOST_VERSION', '2.0.1');
 }
 if (!defined('TYPOST_PLUGIN_DIR')) {
     define('TYPOST_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
…l by upgrading same-host http:// URLs to https:// on secure pages; update version to 2.0.1

This pull request addresses a mixed-content issue in the Glyphs Panel by ensuring that locally-hosted font files referenced via insecure `http://` URLs are automatically upgraded to `https://` when fetched on HTTPS sites. This prevents fonts from being blocked by browsers due to mixed content, improving compatibility and user experience. The update also includes new tests, documentation, and minor UI and documentation improvements.

**Mixed-content fix and font loading improvements:**

* Added a new `normalizeFetchUrl` function in `font-loader.js` to upgrade same-host `http://` font URLs to `https://` when the page is served over HTTPS, preventing mixed-content blocking in browsers. Cross-origin URLs are left unchanged to avoid fetch failures.
* Integrated `normalizeFetchUrl` into the font file fetch logic in `font-loader.js` so that all font file requests in the Glyphs Panel benefit from this upgrade logic. [[1]](diffhunk://#diff-7e76f9dc6690c14d03978fd983f9ddb3f1382f766d318b54143a54be3a2babb1R502-R504) [[2]](diffhunk://#diff-7e76f9dc6690c14d03978fd983f9ddb3f1382f766d318b54143a54be3a2babb1R565-R567)
* Exported `normalizeFetchUrl` for use and added comprehensive unit tests to ensure correct handling of various URL cases. (Ff844f0dL603, [glyphs-panel/__tests__/font-loader.test.jsR9-R47](diffhunk://#diff-a9a80402e70f41e404512f243b04263f7bdff6070c05c2263940022f9d80ecfaR9-R47))

**Documentation and versioning:**

* Updated plugin version numbers in `typography-stylist.php`, `glyphs-panel.php`, and `readme.txt` to `2.0.1` (and internal constant `TYPOST_GP_VERSION` to `1.1.1`) to reflect the new release. [[1]](diffhunk://#diff-8477ec8a3f90e1acada6ac3df511bfaf7e7b3e9ee35435851a2affcbd939737cL6-R6) [[2]](diffhunk://#diff-8477ec8a3f90e1acada6ac3df511bfaf7e7b3e9ee35435851a2affcbd939737cL24-R24) [[3]](diffhunk://#diff-2e93b74511d390967ec47550aac9d50f858a39a9c6331200c15e41a67edeb93aL25-R25) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added changelog and upgrade notice entries describing the mixed-content fix, improved accessibility for help tab headers, corrected REST API documentation, and UI enhancements for the Glyphs Panel. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R278-R280) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R315-R316) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R332-R333) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R476-R478)